### PR TITLE
[0.1.0] HC-8 SecurifyConfig 기본 구성

### DIFF
--- a/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
+++ b/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.github.hurrcook.global.security;
+package com.github.hurrcook.global.config;
 
 import com.github.hurrcook.global.security.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
+++ b/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.github.hurrcook.global.config;
 
+import com.github.hurrcook.global.security.authentication.CustomAuthenticationEntryPoint;
 import com.github.hurrcook.global.security.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +18,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtFilter jwtFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,7 +34,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth-> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated())
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+
+                .exceptionHandling(e-> e
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                );
 
         return http.build();
     }

--- a/src/main/java/com/github/hurrcook/global/security/SecurityConfig.java
+++ b/src/main/java/com/github/hurrcook/global/security/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.github.hurrcook.global.security;
+
+import com.github.hurrcook.global.security.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors-> cors.configurationSource(corsConfigurationSource()))
+
+                .sessionManagement(session-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                .authorizeHttpRequests(auth-> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.addAllowedOrigin("http://localhost:3000"); // 프론트 연동 주소 명시
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.addAllowedMethod("*");
+        corsConfiguration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+        return source;
+    }
+}

--- a/src/main/java/com/github/hurrcook/global/security/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/github/hurrcook/global/security/authentication/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.github.hurrcook.global.security.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.hurrcook.domain.auth.exception.AuthExceptions;
+import com.github.hurrcook.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        // 인증 실패 시 예외 처리
+        ApiResponse<?> apiResponse = ApiResponse.error(AuthExceptions.AUTHENTICATION_FAILED.toApiException());
+
+        String body = objectMapper.writeValueAsString(apiResponse);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(body);
+
+    }
+}


### PR DESCRIPTION
## 📋 변경사항 요약

SecurifyConfig의 기본 설정을 추가했습니다.
임의로 `/api/auth/**` 엔드포인트의 요청을 허용하도록 설정했습니다.

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [x] 문서를 업데이트했습니다 (해당하는 경우)
- [ ] 변경사항이 기존 테스트를 통과합니다
