### PR TITLE
[0.2.0] HC-37 RefreshToken 생성 메서드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     implementation 'com.auth0:java-jwt:4.4.0'
 

--- a/src/main/java/com/github/hurrcook/domain/auth/dto/response/CheckLoginFirst.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/dto/response/CheckLoginFirst.java
@@ -1,0 +1,22 @@
+package com.github.hurrcook.domain.auth.dto.response;
+
+import com.github.hurrcook.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CheckLoginFirst {
+    private User user;
+    private boolean isFirstLogin;
+
+    public static CheckLoginFirst of(User user, boolean isFirstLogin) {
+        return CheckLoginFirst.builder()
+                .user(user)
+                .isFirstLogin(isFirstLogin)
+                .build();
+
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/dto/response/LoginResponse.java
@@ -18,4 +18,6 @@ public class LoginResponse {
     @JsonProperty("accessToken") private String accessToken;
 
     @JsonProperty("refreshToken") private String refreshToken;
+
+    @JsonProperty("isFirstLogin") private boolean isFirstLogin;
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,27 @@
+package com.github.hurrcook.domain.auth.entity;
+
+
+import lombok.Builder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+
+@Builder
+@RedisHash(value = "refresh_token")
+public record RefreshToken(
+        @Id
+        Long id,
+
+        String userId,
+
+        @Indexed
+        String token,
+
+        @TimeToLive(unit = TimeUnit.HOURS)
+        long ttl
+){}

--- a/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
@@ -20,7 +20,7 @@ public record RefreshToken(
         String userId,
 
         @Indexed
-        String token,
+        String refreshToken,
 
         @TimeToLive(unit = TimeUnit.HOURS)
         long ttl

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.github.hurrcook.domain.auth.service;
 import com.github.hurrcook.domain.auth.dto.response.KakaoTokenResponse;
 import com.github.hurrcook.domain.auth.dto.response.KakaoUserInfoResponse;
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
+import com.github.hurrcook.domain.auth.entity.RefreshToken;
 import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.cookware.entity.Cookware;
 import com.github.hurrcook.domain.user.entity.User;
@@ -62,11 +63,10 @@ public class AuthService {
         User user = login(kakaoUserInfoResponse);
 
         // JWT 토큰 생성
-        //TODO: 리프레시 토큰 관련 추가 후 반환 값에 반영
-        String accessToken = jwtUtil.createToken(user);
-//      String refreshToken = jwtUtil.
+        String accessToken = jwtUtil.createAccessToken(user);
+        String refreshToken = jwtUtil.createRefreshToken(user);
 
-        return LoginResponse.of(user.getId(),user.getName(),accessToken, kakaoTokenResponse.getRefreshToken());
+        return LoginResponse.of(user.getId(),user.getName(),accessToken, refreshToken);
     }
 
 

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -1,9 +1,9 @@
 package com.github.hurrcook.domain.auth.service;
 
+import com.github.hurrcook.domain.auth.dto.response.CheckLoginFirst;
 import com.github.hurrcook.domain.auth.dto.response.KakaoTokenResponse;
 import com.github.hurrcook.domain.auth.dto.response.KakaoUserInfoResponse;
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
-import com.github.hurrcook.domain.auth.entity.RefreshToken;
 import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.cookware.entity.Cookware;
 import com.github.hurrcook.domain.user.entity.User;
@@ -59,14 +59,14 @@ public class AuthService {
         KakaoTokenResponse kakaoTokenResponse = getTokenFromKakao(authorizeCode);
         // 토큰으로 유저 정보 받음
         KakaoUserInfoResponse kakaoUserInfoResponse = getUserInfoFromKakao(kakaoTokenResponse.getAccessToken());
-        // 사용자 로그인 (최초 시 회원가입)
-        User user = login(kakaoUserInfoResponse);
 
+        CheckLoginFirst loginResult = login(kakaoUserInfoResponse); // 로그인 결과 반환 (최초 로그인 시 isFirst==ture)
+        User user = loginResult.getUser();
         // JWT 토큰 생성
         String accessToken = jwtUtil.createAccessToken(user);
         String refreshToken = jwtUtil.createRefreshToken(user);
 
-        return LoginResponse.of(user.getId(),user.getName(),accessToken, refreshToken);
+        return LoginResponse.of(user.getId(), user.getName(),accessToken, refreshToken, loginResult.isFirstLogin());
     }
 
 
@@ -74,7 +74,7 @@ public class AuthService {
     /*          내부 메서드          */
 
     /* 서비스 회원가입/로그인 처리 */
-    private User login(KakaoUserInfoResponse kakaoUserInfoResponse){
+    private CheckLoginFirst login(KakaoUserInfoResponse kakaoUserInfoResponse){
         Long kakaoId = kakaoUserInfoResponse.getId();
         String nickname = kakaoUserInfoResponse.getKakaoAccount().getProfile().getNickname();
 
@@ -82,9 +82,13 @@ public class AuthService {
                 .map(existingUser-> { // 유저가 있으면 로그인 처리, 변경 사항을 업데이트
                     existingUser.setName(nickname);
 
-                    return existingUser;
+                    return CheckLoginFirst.of(existingUser, false);
                 })
-                .orElseGet(()-> of(kakaoId,nickname));
+                .orElseGet(()-> {
+                    User newUser = of(kakaoId, nickname); // 유저가 없으면 생성, isFirstLogin을 true로 설정
+
+                    return CheckLoginFirst.of(newUser, true);
+                });
 
     }
 

--- a/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,14 @@
+package com.github.hurrcook.domain.user.repository;
+
+
+import com.github.hurrcook.domain.auth.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/github/hurrcook/global/config/RedisConfig.java
+++ b/src/main/java/com/github/hurrcook/global/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.github.hurrcook.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory); // redis 연결
+
+        // Key는 문자열로, Value는 JSON 형태로 저장하도록 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // Hash용
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/github/hurrcook/global/property/JwtProperty.java
+++ b/src/main/java/com/github/hurrcook/global/property/JwtProperty.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.global.property;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -13,9 +14,9 @@ public class JwtProperty {
     @NotBlank
     private String secretKey;
 
-    @NotBlank
+    @NotNull
     Long accessExpiration;
 
-    @NotBlank
+    @NotNull
     Long refreshExpiration;
 }

--- a/src/main/java/com/github/hurrcook/global/property/JwtProperty.java
+++ b/src/main/java/com/github/hurrcook/global/property/JwtProperty.java
@@ -14,5 +14,8 @@ public class JwtProperty {
     private String secretKey;
 
     @NotBlank
-    Long expiration;
+    Long accessExpiration;
+
+    @NotBlank
+    Long refreshExpiration;
 }

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
@@ -43,13 +43,13 @@ public class JwtUtil {
         String token =  JWT.create()
                 .withIssuedAt(Instant.now())
                 .withExpiresAt(Instant.now().plus(jwtProperty.getRefreshExpiration(), ChronoUnit.HOURS))
-                .withClaim("id",user.getId().toString())
+                .withClaim("id",user.getId().toString()) // baseSchema Id
                 .sign(algorithm());
 
         // refreshToken 엔티티 생성 및 저장
         RefreshToken refreshToken = RefreshToken.builder()
-                .userId(user.getKakaoId().toString())
-                .token(token)
+                .userId(user.getId().toString()) // 토큰에 baseSchema Id로 저장
+                .refreshToken(token)
                 .ttl(jwtProperty.getRefreshExpiration())
                 .build();
 

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
@@ -29,11 +29,18 @@ public class JwtUtil {
         return Algorithm.HMAC256(jwtProperty.getSecretKey());
     }
 
-    public String createToken(User user){
-
+    public String createAccessToken(User user){
         return JWT.create()
                 .withIssuedAt(Instant.now())
-                .withExpiresAt(Instant.now().plus(jwtProperty.getExpiration(), ChronoUnit.HOURS))
+                .withExpiresAt(Instant.now().plus(jwtProperty.getAccessExpiration(), ChronoUnit.HOURS))
+                .withClaim("id",user.getId().toString())
+                .sign(algorithm());
+    }
+
+    public String createRefreshToken(User user){
+        return JWT.create()
+                .withIssuedAt(Instant.now())
+                .withExpiresAt(Instant.now().plus(jwtProperty.getRefreshExpiration(), ChronoUnit.HOURS))
                 .withClaim("id",user.getId().toString())
                 .sign(algorithm());
     }

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
@@ -2,8 +2,10 @@ package com.github.hurrcook.global.security.jwt;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.github.hurrcook.domain.auth.entity.RefreshToken;
 import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.user.entity.User;
+import com.github.hurrcook.domain.user.repository.RefreshTokenRedisRepository;
 import com.github.hurrcook.global.property.JwtProperty;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +22,7 @@ import java.util.UUID;
 @Configuration
 @RequiredArgsConstructor
 public class JwtUtil {
-
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
     private final JwtProperty jwtProperty;
 
     @Bean
@@ -38,11 +40,22 @@ public class JwtUtil {
     }
 
     public String createRefreshToken(User user){
-        return JWT.create()
+        String token =  JWT.create()
                 .withIssuedAt(Instant.now())
                 .withExpiresAt(Instant.now().plus(jwtProperty.getRefreshExpiration(), ChronoUnit.HOURS))
                 .withClaim("id",user.getId().toString())
                 .sign(algorithm());
+
+        // refreshToken 엔티티 생성 및 저장
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(user.getKakaoId().toString())
+                .token(token)
+                .ttl(jwtProperty.getRefreshExpiration())
+                .build();
+
+        refreshTokenRedisRepository.save(refreshToken);
+
+        return token;
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ server:
     context-path: /api
 
 spring:
+  # mysql
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_DATABASE:hurr_cook}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -13,6 +14,21 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+
+  # redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+      database: 0
+      timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+          max-wait: 3000ms
 
 app:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,8 @@ spring:
 app:
   jwt:
     secret-key: ${JWT_SECRET_KEY}
-    expiration: 24
+    access-expiration: 24
+    refresh-expiration: 720 # 24(h)*30(day)
 
   oauth:
     kakao:


### PR DESCRIPTION
## 📋 변경사항 요약

RefreshToken의 ttl을 설정하고 생성 메서드를 추가했습니다.


## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [x] 설정 변경


## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

개발 편의를 위해 리프레시 토큰의 유효기간을 24*30 (한 달)로 설정했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 로그인 시 서버에 저장되는 자체 리프레시 토큰을 발급하고 반환합니다.
  - 로그인 응답에 최초 로그인 여부(isFirstLogin)를 포함합니다.
- 개선
  - 토큰 만료 설정을 액세스/리프레시로 분리해 수명 관리를 명확히 했습니다.
- 설정/운영
  - Redis 연동 및 관련 설정을 추가해 리프레시 토큰의 저장·조회 및 TTL을 지원합니다.
- 기타
  - Redis 런타임 의존성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->