### PR TITLE
[0.2.0] HC-23 레시피 crud 기능 생성

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/recipe/_recipe_food/entity/RecipeFood.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/_recipe_food/entity/RecipeFood.java
@@ -8,11 +8,11 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor(staticName = "of")
-@EqualsAndHashCode(callSuper = true)
 public class RecipeFood extends BaseSchema {
 
     @Column(nullable = false)

--- a/src/main/java/com/github/hurrcook/domain/recipe/_recipe_food/entity/RecipeFood.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/_recipe_food/entity/RecipeFood.java
@@ -1,5 +1,6 @@
 package com.github.hurrcook.domain.recipe._recipe_food.entity;
 
+import com.github.hurrcook.domain.recipe.dto.request.RecipeIngredientRequest;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
 import com.github.hurrcook.global.common.Unit;
 import com.github.hurrcook.global.infra.BaseSchema;
@@ -10,7 +11,7 @@ import lombok.*;
 @Data
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
+@AllArgsConstructor(staticName = "of")
 @EqualsAndHashCode(callSuper = true)
 public class RecipeFood extends BaseSchema {
 
@@ -27,4 +28,8 @@ public class RecipeFood extends BaseSchema {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id",nullable = false)
     Recipe recipe;
+
+    public static RecipeFood from(RecipeIngredientRequest request,Recipe recipe) {
+        return RecipeFood.of(request.getName(),request.getAmount(),request.getUnit(),recipe);
+    }
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/_recipe_food/repository/RecipeFoodRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/_recipe_food/repository/RecipeFoodRepository.java
@@ -1,0 +1,9 @@
+package com.github.hurrcook.domain.recipe._recipe_food.repository;
+
+import com.github.hurrcook.domain.recipe._recipe_food.entity.RecipeFood;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RecipeFoodRepository extends JpaRepository<RecipeFood, UUID> {
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
@@ -1,16 +1,15 @@
 package com.github.hurrcook.domain.recipe.controller;
 
+import com.github.hurrcook.domain.recipe.dto.request.ModifyRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
+import com.github.hurrcook.domain.recipe.entity.Recipe;
 import com.github.hurrcook.domain.recipe.service.RecipeService;
 import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/recipes")
@@ -21,7 +20,16 @@ public class RecipeController {
 
     @PostMapping
     public ApiResponse<Void> saveRecipe(@RequestBody @Valid SaveRecipeRequest saveRecipeRequest, @AuthenticationPrincipal User user) {
+
         recipeService.saveRecipe(saveRecipeRequest,user);
+
+        return ApiResponse.ok();
+    }
+
+    @PutMapping("/{recipe}")
+    public ApiResponse<Void> updateRecipe(@RequestBody @Valid ModifyRecipeRequest modifyRecipeRequest, @PathVariable Recipe recipe, @AuthenticationPrincipal User user) {
+        recipeService.updateRecipe(modifyRecipeRequest,recipe,user);
+
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
@@ -32,4 +32,11 @@ public class RecipeController {
 
         return ApiResponse.ok();
     }
+
+    @DeleteMapping("/{recipe}")
+    public ApiResponse<Void> deleteRecipe(@PathVariable Recipe recipe, @AuthenticationPrincipal User user) {
+        recipeService.deleteRecipe(recipe,user);
+
+        return ApiResponse.ok();
+    }
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
@@ -1,0 +1,27 @@
+package com.github.hurrcook.domain.recipe.controller;
+
+import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
+import com.github.hurrcook.domain.recipe.service.RecipeService;
+import com.github.hurrcook.domain.user.entity.User;
+import com.github.hurrcook.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/recipes")
+@RequiredArgsConstructor
+public class RecipeController {
+
+    private final RecipeService recipeService;
+
+    @PostMapping
+    public ApiResponse<Void> saveRecipe(@RequestBody @Valid SaveRecipeRequest saveRecipeRequest, @AuthenticationPrincipal User user) {
+        recipeService.saveRecipe(saveRecipeRequest,user);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyIngredient.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyIngredient.java
@@ -1,0 +1,16 @@
+package com.github.hurrcook.domain.recipe.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class ModifyIngredient {
+
+    @NotNull
+    UUID id;
+
+    @NotNull
+    Integer amount;
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyRecipeRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyRecipeRequest.java
@@ -1,0 +1,20 @@
+package com.github.hurrcook.domain.recipe.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ModifyRecipeRequest {
+    @NotNull
+    String title;
+
+    @NotNull
+    List<ModifyIngredient> ingredients;
+
+    @NotNull
+    List<String> steps;
+
+
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/RecipeIngredientRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/RecipeIngredientRequest.java
@@ -1,0 +1,18 @@
+package com.github.hurrcook.domain.recipe.dto.request;
+
+import com.github.hurrcook.global.common.Unit;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class RecipeIngredientRequest {
+
+    @NotNull
+    String name;
+
+    @NotNull
+    Integer amount;
+
+    @NotNull
+    Unit unit;
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/SaveRecipeRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/SaveRecipeRequest.java
@@ -1,0 +1,22 @@
+package com.github.hurrcook.domain.recipe.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SaveRecipeRequest {
+
+    @NotNull
+    String title;
+
+    @NotNull
+    List<RecipeIngredientRequest> ingredients;
+
+    @NotNull
+    List<String> steps;
+
+    @NotNull
+    String time;
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/entity/Recipe.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/entity/Recipe.java
@@ -11,11 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Data
+@Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 public class Recipe extends BaseSchema {
 
     @ManyToOne

--- a/src/main/java/com/github/hurrcook/domain/recipe/entity/Recipe.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/entity/Recipe.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.recipe.entity;
 
 import com.github.hurrcook.domain.recipe._recipe_food.entity.RecipeFood;
+import com.github.hurrcook.domain.recipe.dto.request.RecipeIngredientRequest;
 import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.infra.BaseSchema;
 import jakarta.persistence.*;
@@ -25,18 +26,26 @@ public class Recipe extends BaseSchema {
     String title;
 
     @Column(nullable = false)
-    Integer time;
+    String time;
 
     @Column
     String image;
 
     @ElementCollection
     @Builder.Default
-    List<String> contents = new ArrayList<>();
+    List<String> steps = new ArrayList<>();
 
     @OneToMany(mappedBy = "recipe",  cascade = CascadeType.ALL, orphanRemoval = true,fetch = FetchType.LAZY)
     @Builder.Default
     List<RecipeFood> ingredients = new ArrayList<>();
 
+    public void addIngredient(RecipeIngredientRequest request) {
+        RecipeFood recipeFood = RecipeFood.from(request,this);
+        this.ingredients.add(recipeFood);
+    }
+
+    public void addIngredients(List<RecipeIngredientRequest> requests) {
+        requests.forEach(this::addIngredient);
+    }
 
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/exception/RecipeExceptions.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/exception/RecipeExceptions.java
@@ -1,0 +1,14 @@
+package com.github.hurrcook.domain.recipe.exception;
+
+import com.github.hurrcook.global.exception.ApiExceptions;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecipeExceptions implements ApiExceptions {
+
+    RECIPE_ACCESS_DENIED("자신의 레시피만 수정할 수 있습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/repository/RecipeRepository.java
@@ -1,0 +1,7 @@
+package com.github.hurrcook.domain.recipe.repository;
+
+import com.github.hurrcook.domain.recipe.entity.Recipe;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeRepository extends JpaRepository<Recipe, String> {
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/repository/RecipeRepository.java
@@ -3,5 +3,7 @@ package com.github.hurrcook.domain.recipe.repository;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RecipeRepository extends JpaRepository<Recipe, String> {
+import java.util.UUID;
+
+public interface RecipeRepository extends JpaRepository<Recipe, UUID> {
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -1,18 +1,24 @@
 package com.github.hurrcook.domain.recipe.service;
 
+import com.github.hurrcook.domain.recipe._recipe_food.repository.RecipeFoodRepository;
+import com.github.hurrcook.domain.recipe.dto.request.ModifyRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
+import com.github.hurrcook.domain.recipe.exception.RecipeExceptions;
 import com.github.hurrcook.domain.recipe.repository.RecipeRepository;
 import com.github.hurrcook.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class RecipeService {
 
     private final RecipeRepository recipeRepository;
+    private final RecipeFoodRepository recipeFoodRepository;
 
+    @Transactional
     public void saveRecipe(SaveRecipeRequest request, User user){
         Recipe newRecipe = Recipe.builder()
                 .title(request.getTitle())
@@ -24,6 +30,20 @@ public class RecipeService {
         newRecipe.addIngredients(request.getIngredients());
 
         recipeRepository.save(newRecipe);
+    }
+    @Transactional
+    public void updateRecipe(ModifyRecipeRequest request,Recipe recipe, User user){
+        if (!recipe.getUser().equals(user)){
+            throw RecipeExceptions.RECIPE_ACCESS_DENIED.toApiException();
+        }
+
+        recipe.setTitle(request.getTitle());
+        recipe.getSteps().clear();
+        recipe.setSteps(request.getSteps());
+
+
+        request.getIngredients().forEach(ing -> recipeFoodRepository.findById(ing.getId()).ifPresent(recipeFood -> recipeFood.setAmount(ing.getAmount())));
+
     }
 
 

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -46,5 +46,14 @@ public class RecipeService {
 
     }
 
+    @Transactional
+    public void deleteRecipe(Recipe recipe, User user){
+        if (!recipe.getUser().equals(user)){
+            throw RecipeExceptions.RECIPE_ACCESS_DENIED.toApiException();
+        }
+
+        recipeRepository.delete(recipe);
+    }
+
 
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -1,0 +1,30 @@
+package com.github.hurrcook.domain.recipe.service;
+
+import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
+import com.github.hurrcook.domain.recipe.entity.Recipe;
+import com.github.hurrcook.domain.recipe.repository.RecipeRepository;
+import com.github.hurrcook.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeService {
+
+    private final RecipeRepository recipeRepository;
+
+    public void saveRecipe(SaveRecipeRequest request, User user){
+        Recipe newRecipe = Recipe.builder()
+                .title(request.getTitle())
+                .time(request.getTime())
+                .steps(request.getSteps())
+                .user(user)
+                .build();
+
+        newRecipe.addIngredients(request.getIngredients());
+
+        recipeRepository.save(newRecipe);
+    }
+
+
+}

--- a/src/main/java/com/github/hurrcook/domain/user/entity/User.java
+++ b/src/main/java/com/github/hurrcook/domain/user/entity/User.java
@@ -1,10 +1,12 @@
 package com.github.hurrcook.domain.user.entity;
 
 import com.github.hurrcook.domain.cookware.entity.Cookware;
+import com.github.hurrcook.domain.recipe.entity.Recipe;
 import com.github.hurrcook.global.infra.BaseSchema;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
+
+import java.util.List;
 
 @Entity
 @Data
@@ -23,4 +25,7 @@ public class User extends BaseSchema {
 
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private Cookware cookware;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Recipe> recipes;
 }

--- a/src/main/java/com/github/hurrcook/domain/user/entity/User.java
+++ b/src/main/java/com/github/hurrcook/domain/user/entity/User.java
@@ -9,9 +9,9 @@ import lombok.*;
 import java.util.List;
 
 @Entity
-@Data
+@Getter
+@Setter
 @Builder
-@EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")

--- a/src/main/java/com/github/hurrcook/global/common/Unit.java
+++ b/src/main/java/com/github/hurrcook/global/common/Unit.java
@@ -1,7 +1,14 @@
 package com.github.hurrcook.global.common;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum Unit {
-    ml,
-    g,
-    EA
+    ML,
+    G,
+    EA;
+
+    @JsonCreator
+    public static Unit fromString(String value) {
+        return Unit.valueOf(value.toUpperCase());
+    }
 }

--- a/src/main/java/com/github/hurrcook/global/common/Unit.java
+++ b/src/main/java/com/github/hurrcook/global/common/Unit.java
@@ -1,7 +1,7 @@
 package com.github.hurrcook.global.common;
 
 public enum Unit {
-    ML,
-    G,
+    ml,
+    g,
     EA
 }


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 레시피 생성/수정/삭제 API 제공 (/recipes POST/PUT/DELETE).
  - 레시피 저장 시 제목, 조리시간(time, 문자열), 단계(steps), 재료(name/amount/unit) 요청 본문으로 전달.
  - 레시피 수정에서 재료 수량 및 단계 일괄 업데이트 지원.
  - 단위(Unit) 입력을 대소문자 구분 없이 처리(예: ml, g, ea).
  - 본인 소유 레시피만 수정/삭제 가능하며, 권한 없을 경우 접근 거부 메시지 반환.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->