### PR TITLE
[0.2.0] HC-27 재료 등록 기능 구현

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
@@ -1,0 +1,9 @@
+package com.github.hurrcook.domain.ingredient;
+
+import com.github.hurrcook.domain.ingredient.entity.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, UUID> {
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -4,6 +4,8 @@ import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
 import com.github.hurrcook.domain.ingredient.service.IngredientService;
 import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,11 +19,13 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/ingredients")
+@Tag(name = "재료")
 public class IngredientController {
 
     private final IngredientService ingredientService;
 
     @PostMapping("/add")
+    @Operation(summary = "재료 등록")
     public ApiResponse<Void> addIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid List<IngredientRequest> ingredientRequests) {
 
         ingredientService.addIngredient(user, ingredientRequests);

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -24,7 +24,7 @@ public class IngredientController {
 
     private final IngredientService ingredientService;
 
-    @PostMapping("/add")
+    @PostMapping
     @Operation(summary = "재료 등록")
     public ApiResponse<Void> addIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid List<IngredientRequest> ingredientRequests) {
 

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/ingredients")
@@ -20,9 +22,9 @@ public class IngredientController {
     private final IngredientService ingredientService;
 
     @PostMapping("/add")
-    public ApiResponse<Void> addIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid IngredientRequest ingredientRequest) {
+    public ApiResponse<Void> addIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid List<IngredientRequest> ingredientRequests) {
 
-        ingredientService.addIngredient(user, ingredientRequest);
+        ingredientService.addIngredient(user, ingredientRequests);
 
         return ApiResponse.ok();
     }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -1,0 +1,29 @@
+package com.github.hurrcook.domain.ingredient.controller;
+
+import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
+import com.github.hurrcook.domain.ingredient.service.IngredientService;
+import com.github.hurrcook.domain.user.entity.User;
+import com.github.hurrcook.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ingredients")
+public class IngredientController {
+
+    private final IngredientService ingredientService;
+
+    @PostMapping("/add")
+    public ApiResponse<Void> addIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid IngredientRequest ingredientRequest) {
+
+        ingredientService.addIngredient(user, ingredientRequest);
+
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientRequest.java
@@ -1,0 +1,25 @@
+package com.github.hurrcook.domain.ingredient.dto.request;
+
+import com.github.hurrcook.global.common.Unit;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class IngredientRequest {
+
+    @NotBlank
+    String name;
+
+    @Positive
+    int amount;
+
+    @NotNull
+    Unit unit;
+
+    @NotNull
+    LocalDateTime expire_time;
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientRequest.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.ingredient.dto.request;
 
 import com.github.hurrcook.global.common.Unit;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -12,14 +13,18 @@ import java.time.LocalDateTime;
 public class IngredientRequest {
 
     @NotBlank
+    @Schema(description = "재료 이름")
     String name;
 
     @Positive
+    @Schema(description = "수량")
     int amount;
 
     @NotNull
+    @Schema(description = "재료 단위")
     Unit unit;
 
     @NotNull
+    @Schema(description = "유통기한")
     LocalDateTime expire_time;
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/entity/Ingredient.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/entity/Ingredient.java
@@ -1,0 +1,46 @@
+package com.github.hurrcook.domain.ingredient.entity;
+
+import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
+import com.github.hurrcook.domain.user.entity.User;
+import com.github.hurrcook.global.common.Unit;
+import com.github.hurrcook.global.infra.BaseSchema;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Ingredient extends BaseSchema {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    User user;
+
+    @Column(nullable = false)
+    String name;
+
+    @Column(nullable = false)
+    int amount;
+
+    @Column(nullable = false)
+    LocalDateTime expire_time;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    Unit unit;
+
+    public static Ingredient from(User user, IngredientRequest request) {
+        return Ingredient.builder()
+                .user(user)
+                .name(request.getName())
+                .amount(request.getAmount())
+                .expire_time(request.getExpire_time())
+                .unit(request.getUnit())
+                .build();
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -1,0 +1,24 @@
+package com.github.hurrcook.domain.ingredient.service;
+
+import com.github.hurrcook.domain.ingredient.IngredientRepository;
+import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
+import com.github.hurrcook.domain.ingredient.entity.Ingredient;
+import com.github.hurrcook.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class IngredientService {
+
+    private final IngredientRepository ingredientRepository;
+
+    public void addIngredient(User user, IngredientRequest ingredientRequest) {
+
+        Ingredient ingredient = Ingredient.from(user, ingredientRequest);
+
+        ingredientRepository.save(ingredient);
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -15,10 +18,15 @@ public class IngredientService {
 
     private final IngredientRepository ingredientRepository;
 
-    public void addIngredient(User user, IngredientRequest ingredientRequest) {
+    public void addIngredient(User user, List<IngredientRequest> ingredientRequests) {
 
-        Ingredient ingredient = Ingredient.from(user, ingredientRequest);
+        List<Ingredient> ingredients = new ArrayList<>();
 
-        ingredientRepository.save(ingredient);
+        for (IngredientRequest ingredientRequest : ingredientRequests) {
+            ingredients.add(Ingredient.from(user, ingredientRequest));
+
+        }
+
+        ingredientRepository.saveAll(ingredients);
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -13,11 +13,11 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class IngredientService {
 
     private final IngredientRepository ingredientRepository;
 
+    @Transactional
     public void addIngredient(User user, List<IngredientRequest> ingredientRequests) {
 
         List<Ingredient> ingredients = new ArrayList<>();


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [x] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 인증된 사용자가 재료를 일괄 등록할 수 있는 POST /ingredients 엔드포인트 추가.
  - 이름, 수량, 단위, 유통기한 입력에 대한 서버측 유효성 검사 적용.
  - 등록 결과를 표준 응답 포맷으로 반환.

- 문서
  - API 문서에 재료 등록 엔드포인트 및 요청 스키마(필드 설명 포함) 추가.
  - 재료 관련 태그와 요약으로 가시성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->