### PR TITLE
[0.2.0] HC-24 레시피 목록 불러오기 api 요청 생성

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
@@ -2,6 +2,7 @@ package com.github.hurrcook.domain.recipe.controller;
 
 import com.github.hurrcook.domain.recipe.dto.request.ModifyRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
+import com.github.hurrcook.domain.recipe.dto.response.RecipeListResponse;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
 import com.github.hurrcook.domain.recipe.service.RecipeService;
 import com.github.hurrcook.domain.user.entity.User;
@@ -39,4 +40,10 @@ public class RecipeController {
 
         return ApiResponse.ok();
     }
+
+    @GetMapping ApiResponse<RecipeListResponse> getRecipeList(@AuthenticationPrincipal User user) {
+
+        return ApiResponse.ok(recipeService.getRecipeList(user));
+    }
+
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeListResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeListResponse.java
@@ -1,0 +1,18 @@
+package com.github.hurrcook.domain.recipe.dto.response;
+
+import com.github.hurrcook.domain.recipe.entity.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor(staticName = "of")
+public class RecipeListResponse {
+
+    List<SimpleRecipeResponse> recipes;
+
+    public static RecipeListResponse from(List<Recipe> recipes){
+        return RecipeListResponse.of(recipes.stream().map(SimpleRecipeResponse::from).toList());
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/response/SimpleRecipeResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/response/SimpleRecipeResponse.java
@@ -1,0 +1,26 @@
+package com.github.hurrcook.domain.recipe.dto.response;
+
+import com.github.hurrcook.domain.recipe.entity.Recipe;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor(staticName = "of")
+public class SimpleRecipeResponse {
+    @NotNull
+    String title;
+
+    @NotNull
+    UUID id;
+
+    @Nullable
+    String image;
+
+    public static SimpleRecipeResponse from(Recipe recipe){
+        return SimpleRecipeResponse.of(recipe.getTitle(), recipe.getId(), recipe.getImage());
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/repository/RecipeRepository.java
@@ -1,9 +1,12 @@
 package com.github.hurrcook.domain.recipe.repository;
 
 import com.github.hurrcook.domain.recipe.entity.Recipe;
+import com.github.hurrcook.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface RecipeRepository extends JpaRepository<Recipe, UUID> {
+    List<Recipe> findAllByUser(User user);
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -59,8 +59,7 @@ public class RecipeService {
 
     @Transactional
     public RecipeListResponse getRecipeList(User user){
-
-        return RecipeListResponse.from(user.getRecipes());
+        return RecipeListResponse.from(recipeRepository.findAllByUser(user));
     }
 
 

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -3,6 +3,7 @@ package com.github.hurrcook.domain.recipe.service;
 import com.github.hurrcook.domain.recipe._recipe_food.repository.RecipeFoodRepository;
 import com.github.hurrcook.domain.recipe.dto.request.ModifyRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
+import com.github.hurrcook.domain.recipe.dto.response.RecipeListResponse;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
 import com.github.hurrcook.domain.recipe.exception.RecipeExceptions;
 import com.github.hurrcook.domain.recipe.repository.RecipeRepository;
@@ -10,6 +11,7 @@ import com.github.hurrcook.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +55,12 @@ public class RecipeService {
         }
 
         recipeRepository.delete(recipe);
+    }
+
+    @Transactional
+    public RecipeListResponse getRecipeList(User user){
+
+        return RecipeListResponse.from(user.getRecipes());
     }
 
 


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 로그인된 사용자의 레시피 목록을 조회하는 API 추가: GET /recipes
  - 응답은 각 레시피의 기본 정보(제목, 고유 ID, 이미지 URL[선택])를 포함한 목록 형태로 제공
  - 사용자는 자신의 레시피를 빠르게 확인·목록화할 수 있으며, 목록/카드형 UI에 바로 활용 가능
  - 기존 기능과의 호환성 유지, 인증된 사용자에 한해 접근 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->