### PR TITLE
[0.2.0] HC-25 레시피 상세 조회 api생성 및 swagger 적용

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
@@ -32,15 +32,15 @@ public class RecipeController {
     }
 
     @PutMapping("/{recipe}")
-    public ApiResponse<Void> updateRecipe(@RequestBody @Valid ModifyRecipeRequest modifyRecipeRequest, @PathVariable Recipe recipe, @AuthenticationPrincipal User user) {
-        recipeService.updateRecipe(modifyRecipeRequest,recipe,user);
+    public ApiResponse<Void> updateRecipe(@RequestBody @Valid ModifyRecipeRequest modifyRecipeRequest, @PathVariable Recipe recipe) {
+        recipeService.updateRecipe(modifyRecipeRequest,recipe);
 
         return ApiResponse.ok();
     }
 
     @DeleteMapping("/{recipe}")
-    public ApiResponse<Void> deleteRecipe(@PathVariable Recipe recipe, @AuthenticationPrincipal User user) {
-        recipeService.deleteRecipe(recipe,user);
+    public ApiResponse<Void> deleteRecipe(@PathVariable Recipe recipe) {
+        recipeService.deleteRecipe(recipe);
 
         return ApiResponse.ok();
     }

--- a/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
@@ -24,6 +24,7 @@ public class RecipeController {
     private final RecipeService recipeService;
 
     @PostMapping
+    @Operation(summary = "레시피 저장")
     public ApiResponse<Void> saveRecipe(@RequestBody @Valid SaveRecipeRequest saveRecipeRequest, @AuthenticationPrincipal User user) {
 
         recipeService.saveRecipe(saveRecipeRequest,user);
@@ -32,20 +33,26 @@ public class RecipeController {
     }
 
     @PutMapping("/{recipe}")
-    public ApiResponse<Void> updateRecipe(@RequestBody @Valid ModifyRecipeRequest modifyRecipeRequest, @PathVariable Recipe recipe) {
+    @Operation(summary = "레시피 수정")
+    public ApiResponse<Void> updateRecipe(@RequestBody @Valid ModifyRecipeRequest modifyRecipeRequest, @Parameter(description = "레시피 ID",schema = @Schema(type = "string", format = "uuid")) @PathVariable Recipe recipe) {
+
         recipeService.updateRecipe(modifyRecipeRequest,recipe);
 
         return ApiResponse.ok();
     }
 
     @DeleteMapping("/{recipe}")
-    public ApiResponse<Void> deleteRecipe(@PathVariable Recipe recipe) {
+    @Operation(summary = "레시피 삭제")
+    public ApiResponse<Void> deleteRecipe(@Parameter(description = "레시피 ID",schema = @Schema(type = "string", format = "uuid")) @PathVariable Recipe recipe) {
+
         recipeService.deleteRecipe(recipe);
 
         return ApiResponse.ok();
     }
 
-    @GetMapping ApiResponse<RecipeListResponse> getRecipeList(@AuthenticationPrincipal User user) {
+    @GetMapping
+    @Operation(summary = "레시피 목록 조회")
+    public ApiResponse<RecipeListResponse> getRecipeList(@AuthenticationPrincipal User user) {
 
         return ApiResponse.ok(recipeService.getRecipeList(user));
     }

--- a/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/controller/RecipeController.java
@@ -3,10 +3,14 @@ package com.github.hurrcook.domain.recipe.controller;
 import com.github.hurrcook.domain.recipe.dto.request.ModifyRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.response.RecipeListResponse;
+import com.github.hurrcook.domain.recipe.dto.response.RecipeResponse;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
 import com.github.hurrcook.domain.recipe.service.RecipeService;
 import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -44,6 +48,12 @@ public class RecipeController {
     @GetMapping ApiResponse<RecipeListResponse> getRecipeList(@AuthenticationPrincipal User user) {
 
         return ApiResponse.ok(recipeService.getRecipeList(user));
+    }
+
+    @GetMapping("/{recipe}")
+    @Operation(summary = "레시피 상세 조회")
+    public ApiResponse<RecipeResponse> getRecipeDetail(@Parameter(description = "레시피 ID",schema = @Schema(type = "string", format = "uuid")) @PathVariable Recipe recipe) {
+        return ApiResponse.ok(recipeService.getRecipe(recipe));
     }
 
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyIngredient.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyIngredient.java
@@ -1,5 +1,6 @@
 package com.github.hurrcook.domain.recipe.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -9,8 +10,10 @@ import java.util.UUID;
 public class ModifyIngredient {
 
     @NotNull
+    @Schema(description = "재료 ID")
     UUID id;
 
     @NotNull
+    @Schema(description = "수량")
     Integer amount;
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyRecipeRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/ModifyRecipeRequest.java
@@ -1,5 +1,6 @@
 package com.github.hurrcook.domain.recipe.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -8,12 +9,15 @@ import java.util.List;
 @Data
 public class ModifyRecipeRequest {
     @NotNull
+    @Schema(description = "레시피 제목")
     String title;
 
     @NotNull
+    @Schema(description = "재료 리스트")
     List<ModifyIngredient> ingredients;
 
     @NotNull
+    @Schema(description = "레시피 내용")
     List<String> steps;
 
 

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/RecipeIngredientRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/RecipeIngredientRequest.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.recipe.dto.request;
 
 import com.github.hurrcook.global.common.Unit;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -8,11 +9,14 @@ import lombok.Data;
 public class RecipeIngredientRequest {
 
     @NotNull
+    @Schema(description = "재료 명")
     String name;
 
     @NotNull
+    @Schema(description = "재료 양")
     Integer amount;
 
     @NotNull
+    @Schema(description = "재료 단위")
     Unit unit;
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/request/SaveRecipeRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/request/SaveRecipeRequest.java
@@ -1,5 +1,7 @@
 package com.github.hurrcook.domain.recipe.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -9,14 +11,22 @@ import java.util.List;
 public class SaveRecipeRequest {
 
     @NotNull
+    @Schema(description = "레시피 제목")
     String title;
 
     @NotNull
+    @Schema(description = "레시피 재료")
     List<RecipeIngredientRequest> ingredients;
 
     @NotNull
+    @Schema(description = "레시피 내용")
     List<String> steps;
 
     @NotNull
+    @Schema(description = "걸리는 시간")
     String time;
+
+    @Nullable
+    @Schema(description = "레시피 사진")
+    String image;
 }

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeIngredientResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeIngredientResponse.java
@@ -1,0 +1,31 @@
+package com.github.hurrcook.domain.recipe.dto.response;
+
+import com.github.hurrcook.domain.recipe._recipe_food.entity.RecipeFood;
+import com.github.hurrcook.global.common.Unit;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor(staticName = "of")
+@Schema(description = "재료 응답")
+public class RecipeIngredientResponse {
+
+    @Schema(description = "재료 id")
+    UUID id;
+
+    @Schema(description = "재료 명")
+    String name;
+
+    @Schema(description = "재료 양")
+    Integer amount;
+
+    @Schema(description = "단위")
+    Unit unit;
+
+    public static RecipeIngredientResponse from(RecipeFood recipeFood) {
+        return RecipeIngredientResponse.of(recipeFood.getId(),recipeFood.getName(),recipeFood.getAmount(),recipeFood.getUnit());
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeListResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeListResponse.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.recipe.dto.response;
 
 import com.github.hurrcook.domain.recipe.entity.Recipe;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -10,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor(staticName = "of")
 public class RecipeListResponse {
 
+    @Schema(description = "레시피 목록")
     List<SimpleRecipeResponse> recipes;
 
     public static RecipeListResponse from(List<Recipe> recipes){

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/response/RecipeResponse.java
@@ -1,0 +1,35 @@
+package com.github.hurrcook.domain.recipe.dto.response;
+
+import com.github.hurrcook.domain.recipe.entity.Recipe;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor(staticName = "of")
+@Schema(description = "레시피 응답")
+public class RecipeResponse {
+
+    @Schema(description = "레시피 제목")
+    String title;
+
+    @Schema(description = "재료 리스트")
+    List<RecipeIngredientResponse> ingredients;
+
+    @Schema(description = "요리법")
+    List<String> steps;
+
+    @Schema(description = "이미지 url")
+    String image;
+
+    public static RecipeResponse from(Recipe recipe) {
+        return RecipeResponse.of(
+                recipe.getTitle(),
+                recipe.getIngredients().stream().map(RecipeIngredientResponse::from).toList(),
+                recipe.getSteps(),
+                recipe.getImage()
+        );
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/response/SimpleRecipeResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/response/SimpleRecipeResponse.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.recipe.dto.response;
 
 import com.github.hurrcook.domain.recipe.entity.Recipe;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -10,10 +11,13 @@ import java.util.UUID;
 @AllArgsConstructor(staticName = "of")
 public class SimpleRecipeResponse {
 
+    @Schema(description = "레시피 제목")
     String title;
 
+    @Schema(description = "레시피 ID")
     UUID id;
 
+    @Schema(description = "레시피 사진")
     String image;
 
     public static SimpleRecipeResponse from(Recipe recipe){

--- a/src/main/java/com/github/hurrcook/domain/recipe/dto/response/SimpleRecipeResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/dto/response/SimpleRecipeResponse.java
@@ -1,8 +1,6 @@
 package com.github.hurrcook.domain.recipe.dto.response;
 
 import com.github.hurrcook.domain.recipe.entity.Recipe;
-import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -11,13 +9,11 @@ import java.util.UUID;
 @Data
 @AllArgsConstructor(staticName = "of")
 public class SimpleRecipeResponse {
-    @NotNull
+
     String title;
 
-    @NotNull
     UUID id;
 
-    @Nullable
     String image;
 
     public static SimpleRecipeResponse from(Recipe recipe){

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -4,11 +4,13 @@ import com.github.hurrcook.domain.recipe._recipe_food.repository.RecipeFoodRepos
 import com.github.hurrcook.domain.recipe.dto.request.ModifyRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.response.RecipeListResponse;
+import com.github.hurrcook.domain.recipe.dto.response.RecipeResponse;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
 import com.github.hurrcook.domain.recipe.exception.RecipeExceptions;
 import com.github.hurrcook.domain.recipe.repository.RecipeRepository;
 import com.github.hurrcook.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +62,13 @@ public class RecipeService {
     @Transactional
     public RecipeListResponse getRecipeList(User user){
         return RecipeListResponse.from(recipeRepository.findAllByUser(user));
+    }
+
+    @Transactional
+    @PreAuthorize("#recipe.user.id == authentication.principal.id")
+    public RecipeResponse getRecipe(Recipe recipe){
+
+        return  RecipeResponse.from(recipe);
     }
 
 

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -6,7 +6,6 @@ import com.github.hurrcook.domain.recipe.dto.request.SaveRecipeRequest;
 import com.github.hurrcook.domain.recipe.dto.response.RecipeListResponse;
 import com.github.hurrcook.domain.recipe.dto.response.RecipeResponse;
 import com.github.hurrcook.domain.recipe.entity.Recipe;
-import com.github.hurrcook.domain.recipe.exception.RecipeExceptions;
 import com.github.hurrcook.domain.recipe.repository.RecipeRepository;
 import com.github.hurrcook.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -36,10 +35,9 @@ public class RecipeService {
         recipeRepository.save(newRecipe);
     }
     @Transactional
-    public void updateRecipe(ModifyRecipeRequest request,Recipe recipe, User user){
-        if (!recipe.getUser().equals(user)){
-            throw RecipeExceptions.RECIPE_ACCESS_DENIED.toApiException();
-        }
+    @PreAuthorize("#recipe.user.id == authentication.principal.id")
+    public void updateRecipe(ModifyRecipeRequest request,Recipe recipe){
+
 
         recipe.setTitle(request.getTitle());
         recipe.getSteps().clear();
@@ -51,10 +49,9 @@ public class RecipeService {
     }
 
     @Transactional
-    public void deleteRecipe(Recipe recipe, User user){
-        if (!recipe.getUser().equals(user)){
-            throw RecipeExceptions.RECIPE_ACCESS_DENIED.toApiException();
-        }
+    @PreAuthorize("#recipe.user.id == authentication.principal.id")
+    public void deleteRecipe(Recipe recipe){
+
 
         recipeRepository.delete(recipe);
     }

--- a/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
+++ b/src/main/java/com/github/hurrcook/domain/recipe/service/RecipeService.java
@@ -27,6 +27,7 @@ public class RecipeService {
                 .title(request.getTitle())
                 .time(request.getTime())
                 .steps(request.getSteps())
+                .image(request.getImage())
                 .user(user)
                 .build();
 

--- a/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
+++ b/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.github.hurrcook.global.security.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -16,6 +17,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMethodSecurity()
 public class SecurityConfig {
     private final JwtFilter jwtFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;

--- a/src/main/java/com/github/hurrcook/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/github/hurrcook/global/exception/ApiExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.github.hurrcook.global.exception;
 
 import com.github.hurrcook.global.response.ApiResponse;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
@@ -11,5 +13,10 @@ public class ApiExceptionHandler {
     public ApiResponse<Void> handleApiException(ApiException e){
 
         return ApiResponse.error(e);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ApiResponse<Void> AccessDeniedException(AccessDeniedException e){
+        return ApiResponse.error("권한이 없습니다.");
     }
 }


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 레시피 상세 조회 엔드포인트 추가
  - 레시피 저장 시 이미지(선택) 업로드 필드 지원
- Security
  - 레시피 조회/수정/삭제에 소유자 권한 검증 적용
  - 권한 없음 발생 시 명확한 에러 응답 제공
- Documentation
  - 레시피 관련 요청/응답 필드에 OpenAPI(Swagger) 설명 추가
  - 엔드포인트별 요약 및 파라미터 설명 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->