### PR TITLE
[0.2.0] HC-35 로그아웃 구현

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
@@ -3,8 +3,10 @@ package com.github.hurrcook.domain.auth.controller;
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
 import com.github.hurrcook.domain.auth.service.AuthService;
 import com.github.hurrcook.global.response.ApiResponse;
+import com.github.hurrcook.global.security.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -20,18 +22,25 @@ import java.io.IOException;
 @Tag(name = "인증")
 public class AuthController {
     private final AuthService authService;
+    private final JwtUtil jwtUtil;
 
     // client에서 로그인 요청 -> 로그인 페이지로 리다이렉트
     @GetMapping("/kakao/login")
     @Operation(summary = "로그인 요청")
     public void redirectToKakaoLogin(HttpServletResponse response) throws IOException {
         response.sendRedirect(authService.getKakaoLoginUrl());
-//        return ApiResponse.ok();
     }
 
     @GetMapping("/kakao/callback") // 사용자 인증 후 쿼리 파라미터에 인가 코드를 담아 callback 되어 토큰 발급 요청
     @Operation(summary = "토큰 발급 요청")
     public ApiResponse<LoginResponse> callback(@RequestParam("code") @NotBlank String authorizeCode) {
         return ApiResponse.ok(authService.kakaoLogin(authorizeCode));
+    }
+
+    @GetMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자 세션 종료: 리프레시 토큰 삭제, 액세스 토큰 블랙리스트 처리")
+    public ApiResponse<Void> logout(HttpServletRequest request) { // 현재 액세스 토큰으로 요청
+        authService.logout(jwtUtil.extractToken(request));
+        return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.auth.controller;
 
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
+import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.auth.service.AuthService;
 import com.github.hurrcook.global.response.ApiResponse;
 import com.github.hurrcook.global.security.jwt.JwtUtil;
@@ -37,10 +38,14 @@ public class AuthController {
         return ApiResponse.ok(authService.kakaoLogin(authorizeCode));
     }
 
-    @GetMapping("/logout")
+    @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "사용자 세션 종료: 리프레시 토큰 삭제, 액세스 토큰 블랙리스트 처리")
     public ApiResponse<Void> logout(HttpServletRequest request) { // 현재 액세스 토큰으로 요청
-        authService.logout(jwtUtil.extractToken(request));
+        String accessToken = jwtUtil.extractToken(request);
+        if (accessToken == null || accessToken.isBlank()) {
+            AuthExceptions.INVALID_TOKEN.toApiException();
+        }
+        authService.logout(accessToken);
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
@@ -17,6 +17,7 @@ public record RefreshToken(
         @Id
         Long id,
 
+        @Indexed
         String userId,
 
         @Indexed

--- a/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/entity/RefreshToken.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 

--- a/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum AuthExceptions implements ApiExceptions {
 
     ACCESS_TOKEN_EXPIRED("엑세스 토큰이 만료되었습니다"),
+    INVALID_TOKEN("유효하지 않은 토큰입니다."),
     AUTHENTICATION_FAILED("인증에 실패했습니다."),
     KAKAO_TOKEN_ISSUE_FAILED("카카오 토큰 발급에 실패했습니다."),
     KAKAO_USERINFO_REQUEST_FAILED("카카오 사용자 정보 조회에 실패했습니다.");

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.github.hurrcook.domain.auth.service;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.github.hurrcook.domain.auth.dto.response.CheckLoginFirst;
 import com.github.hurrcook.domain.auth.dto.response.KakaoTokenResponse;
 import com.github.hurrcook.domain.auth.dto.response.KakaoUserInfoResponse;
@@ -7,10 +9,13 @@ import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
 import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.cookware.entity.Cookware;
 import com.github.hurrcook.domain.user.entity.User;
+import com.github.hurrcook.domain.user.exception.UserExceptions;
+import com.github.hurrcook.domain.user.repository.RefreshTokenRedisRepository;
 import com.github.hurrcook.domain.user.repository.UserRepository;
 import com.github.hurrcook.global.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,12 +24,18 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class AuthService {
     private final JwtUtil jwtUtil;
     private final RestTemplate restTemplate;
     private final UserRepository userRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Value("${app.oauth.kakao.client-id}")
     private String clientId;
@@ -35,9 +46,9 @@ public class AuthService {
     @Value("${app.oauth.kakao.client-secret}")
     private String clientSecret;
 
-    private final String KAKAO_AUTH_URL = "https://kauth.kakao.com/oauth/authorize";
-    private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
-    private final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_AUTH_URL = "https://kauth.kakao.com/oauth/authorize";
+    private static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
 
 
@@ -67,6 +78,35 @@ public class AuthService {
         String refreshToken = jwtUtil.createRefreshToken(user);
 
         return LoginResponse.of(user.getId(), user.getName(),accessToken, refreshToken, loginResult.isFirstLogin());
+    }
+
+
+    /* 사용자 로그아웃: 액세스토큰 블랙리스트, 리프레시 토큰 삭제 */
+    @Transactional
+    public void logout(String accessToken){
+        try{
+            // 토큰에서 userId 추출
+            UUID userId = jwtUtil.extractIdFromToken(accessToken);
+
+            // 유저 유효성 검사
+            if (!userRepository.existsById(userId))
+                throw UserExceptions.USER_NOT_FOUND.toApiException();
+
+            refreshTokenRedisRepository.deleteById(userId); // 유저의 리프레시 토큰 삭제
+
+            /* 액세스 토큰을 redis에 저장(blacked 상태) */
+            Instant expiration = jwtUtil.extractExpirationFromToken(accessToken); // 액세스 토큰 ttl
+            Long remainingExpiration = expiration.toEpochMilli() - Instant.now().toEpochMilli(); // 남은 유효시간
+
+            // 남은 유효시간 만큼 블랙 리스트에 저장
+            if (remainingExpiration > 0) {
+                String key = "BLACKED_TOKEN" + accessToken;
+                String value = "blacklisted";
+                redisTemplate.opsForValue().set(key, value, Duration.ofMillis(remainingExpiration));
+            }
+        } catch (JWTVerificationException e){
+            throw AuthExceptions.INVALID_TOKEN.toApiException();
+        }
     }
 
 

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -1,7 +1,6 @@
 package com.github.hurrcook.domain.auth.service;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.github.hurrcook.domain.auth.dto.response.CheckLoginFirst;
 import com.github.hurrcook.domain.auth.dto.response.KakaoTokenResponse;
 import com.github.hurrcook.domain.auth.dto.response.KakaoUserInfoResponse;
@@ -92,11 +91,11 @@ public class AuthService {
             if (!userRepository.existsById(userId))
                 throw UserExceptions.USER_NOT_FOUND.toApiException();
 
-            refreshTokenRedisRepository.deleteById(userId); // 유저의 리프레시 토큰 삭제
+            refreshTokenRedisRepository.deleteByUserId(userId.toString()); // 유저의 리프레시 토큰 삭제
 
             /* 액세스 토큰을 redis에 저장(blacked 상태) */
             Instant expiration = jwtUtil.extractExpirationFromToken(accessToken); // 액세스 토큰 ttl
-            Long remainingExpiration = expiration.toEpochMilli() - Instant.now().toEpochMilli(); // 남은 유효시간
+            long remainingExpiration = expiration.toEpochMilli() - Instant.now().toEpochMilli(); // 남은 유효시간
 
             // 남은 유효시간 만큼 블랙 리스트에 저장
             if (remainingExpiration > 0) {

--- a/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 @Repository
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+    Optional<RefreshToken> deleteById(UUID userId);
 }

--- a/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
@@ -11,5 +11,5 @@ import java.util.UUID;
 @Repository
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
-    Optional<RefreshToken> deleteById(UUID userId);
+    void deleteById(String userId);
 }

--- a/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
@@ -11,5 +11,5 @@ import java.util.UUID;
 @Repository
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
-    void deleteById(String userId);
+    void deleteByUserId(String userId);
 }

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtFilter.java
@@ -14,6 +14,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -28,6 +29,7 @@ public class JwtFilter extends OncePerRequestFilter {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, Object> redisTemplate;
 
 
     @Override
@@ -41,6 +43,12 @@ public class JwtFilter extends OncePerRequestFilter {
 
         try{
             if (jwtUtil.validateToken(accessToken)) {
+
+                // 요청 시 black 처리된 액세스 토큰인지 확인
+                String key = "BLACKED_TOKEN" + accessToken;
+                if (redisTemplate.hasKey(key)) {
+                    throw AuthExceptions.INVALID_TOKEN.toApiException();
+                }
 
                 UUID id = jwtUtil.extractIdFromToken(accessToken);
                 User user = userRepository.findById(id)

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
@@ -16,6 +16,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -96,7 +97,12 @@ public class JwtUtil {
     }
 
     public Instant extractExpirationFromToken(String token){
+        var verified = JWT.require(algorithm()).build().verify(token);
+        Date exp = verified.getExpiresAt();
 
-        return JWT.decode(token).getExpiresAt().toInstant();
+        if (exp == null) {
+            throw AuthExceptions.INVALID_TOKEN.toApiException();
+        }
+        return exp.toInstant();
     }
 }

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
@@ -94,4 +94,9 @@ public class JwtUtil {
 
         return JWT.decode(token).getClaim("id").as(UUID.class);
     }
+
+    public Instant extractExpirationFromToken(String token){
+
+        return JWT.decode(token).getExpiresAt().toInstant();
+    }
 }


### PR DESCRIPTION
## 📋 변경사항 요약

유저의 로그아웃 처리를 위한 API를 구현했습니다.

## 🔧 주요 변경사항

유저의 액세스 토큰을 헤더에 포함하여 요청,
해당 액세스 토큰은 블랙 리스트(레디스)로 저장
기존 유저의 리프레시 토큰을 삭제
유효하지 않은 토큰으로 요청 시 예외

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경


## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - POST /auth/logout 추가로 사용자가 세션을 종료할 수 있습니다.
  - Redis 기반 블랙리스트로 로그아웃된 액세스 토큰을 차단해 재사용을 방지합니다.

- 버그 수정
  - 유효하지 않은 토큰 처리 시 명확한 오류 응답("유효하지 않은 토큰입니다.")을 반환하도록 개선했습니다.

- 기타
  - 액세스 토큰 만료 시간을 활용해 블랙리스트 보존 기간을 설정합니다.
  - 기존 로그인/카카오 콜백 동작은 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->