### PR TITLE
[0.2.0] HC-29 재료 목룍 조회 API

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 import java.util.UUID;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, UUID> {
-    List<Ingredient> findIngredientByUser(User user);
+    List<Ingredient> findAllByUser(User user);
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
@@ -1,9 +1,12 @@
 package com.github.hurrcook.domain.ingredient;
 
 import com.github.hurrcook.domain.ingredient.entity.Ingredient;
+import com.github.hurrcook.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, UUID> {
+    List<Ingredient> findIngredientByUser(User user);
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.ingredient.controller;
 
 import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
+import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.service.IngredientService;
 import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.response.ApiResponse;
@@ -9,10 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -31,5 +29,11 @@ public class IngredientController {
         ingredientService.addIngredient(user, ingredientRequests);
 
         return ApiResponse.ok();
+    }
+
+    @GetMapping()
+    @Operation(summary = "재료 목록 조회")
+    public ApiResponse<List<IngredientResponse>> getAllIngredients(@AuthenticationPrincipal User user) {
+        return ApiResponse.ok(ingredientService.getIngredients(user));
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientRequest.java
@@ -1,3 +1,4 @@
+
 package com.github.hurrcook.domain.ingredient.dto.request;
 
 import com.github.hurrcook.global.common.Unit;
@@ -26,5 +27,5 @@ public class IngredientRequest {
 
     @NotNull
     @Schema(description = "유통기한")
-    LocalDateTime expire_time;
+    LocalDateTime expireDate;
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientResponse.java
@@ -1,4 +1,38 @@
 package com.github.hurrcook.domain.ingredient.dto.response;
 
+import com.github.hurrcook.domain.ingredient.entity.Ingredient;
+import com.github.hurrcook.global.common.Unit;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder @Getter
 public class IngredientResponse {
+    @Schema(description = "재료 id")
+    UUID userFoodId;
+
+    @Schema(description = "재료명")
+    String name;
+
+    @Schema(description = "재료의 양")
+    int amount;
+
+    @Schema(description = "재료 유통기한")
+    LocalDateTime expireDate;
+
+    @Schema(description = "재료 단위")
+    Unit unit;
+
+    public static IngredientResponse from(Ingredient ingredient) {
+        return IngredientResponse.builder()
+                .userFoodId(ingredient.getId())
+                .name(ingredient.getName())
+                .amount(ingredient.getAmount())
+                .expireDate(ingredient.getExpireDate())
+                .unit(ingredient.getUnit())
+                .build();
+    }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientResponse.java
@@ -1,0 +1,4 @@
+package com.github.hurrcook.domain.ingredient.dto.response;
+
+public class IngredientResponse {
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/entity/Ingredient.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/entity/Ingredient.java
@@ -28,7 +28,7 @@ public class Ingredient extends BaseSchema {
     int amount;
 
     @Column(nullable = false)
-    LocalDateTime expire_time;
+    LocalDateTime expireDate;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -39,7 +39,7 @@ public class Ingredient extends BaseSchema {
                 .user(user)
                 .name(request.getName())
                 .amount(request.getAmount())
-                .expire_time(request.getExpire_time())
+                .expireDate(request.getExpireDate())
                 .unit(request.getUnit())
                 .build();
     }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -2,6 +2,7 @@ package com.github.hurrcook.domain.ingredient.service;
 
 import com.github.hurrcook.domain.ingredient.IngredientRepository;
 import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
+import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.entity.Ingredient;
 import com.github.hurrcook.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +29,14 @@ public class IngredientService {
         }
 
         ingredientRepository.saveAll(ingredients);
+    }
+
+    // 유저가 가진 모든 재료 조회
+    @Transactional(readOnly = true)
+    public List<IngredientResponse> getIngredients(User user) {
+        return ingredientRepository.findIngredientByUser(user)
+                .stream()
+                .map(IngredientResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -34,7 +34,7 @@ public class IngredientService {
     // 유저가 가진 모든 재료 조회
     @Transactional(readOnly = true)
     public List<IngredientResponse> getIngredients(User user) {
-        return ingredientRepository.findIngredientByUser(user)
+        return ingredientRepository.findAllByUser(user)
                 .stream()
                 .map(IngredientResponse::from)
                 .toList();


### PR DESCRIPTION
## 📋 변경사항 요약

재료 목록 조회 API를 구현했습니다.

## 🔧 주요 변경사항
재료 목록 조회 요청 시 아래의 필드를 가지는 리스트를 반환합니다.
    UUID userFoodId;
    String name;
    int amount;
    LocalDateTime expireDate;
    Unit unit;

Ingredient 엔티티의 필드를 아래와 같이 수정했습니다.
`expire_time` -> `expireDate`

- [x] 새로운 기능 추가
- [x] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 인증된 사용자의 재료 목록 조회 API 추가(엔드포인트 및 서비스). 재료별 식별자, 이름, 수량, 단위, 유통기한(expireDate)을 반환하는 응답 DTO 추가.
- Refactor
  - 만료일 필드명 expire_time을 expireDate로 통일(요청/응답/엔티티).
- Documentation
  - 재료 목록 조회와 필드명 변경을 API 문서(Swagger)에 반영.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->