### PR TITLE
[HC-30] feat(ingredient): 특정 재료 조회 api 구현

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
@@ -5,8 +5,10 @@ import com.github.hurrcook.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, UUID> {
     List<Ingredient> findAllByUser(User user);
+    Optional<Ingredient> findIngredientByIdAndUser(UUID ingredientId, User user);
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/IngredientRepository.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, UUID> {
     List<Ingredient> findAllByUser(User user);
-    Optional<Ingredient> findIngredientByIdAndUser(UUID ingredientId, User user);
+    Optional<Ingredient> findByIdAndUser(UUID ingredientId, User user);
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,5 +36,11 @@ public class IngredientController {
     @Operation(summary = "재료 목록 조회")
     public ApiResponse<List<IngredientResponse>> getAllIngredients(@AuthenticationPrincipal User user) {
         return ApiResponse.ok(ingredientService.getIngredients(user));
+    }
+
+    @GetMapping("/{ingredientId}")
+    @Operation(summary = "단일 재료 조회")
+    public ApiResponse<IngredientResponse> getIngredient(@AuthenticationPrincipal User user, @PathVariable UUID ingredientId) {
+        return ApiResponse.ok(ingredientService.getIngredient(user, ingredientId));
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/exception/IngredientExceptions.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/exception/IngredientExceptions.java
@@ -1,0 +1,14 @@
+package com.github.hurrcook.domain.ingredient.exception;
+
+import com.github.hurrcook.global.exception.ApiExceptions;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum IngredientExceptions implements ApiExceptions {
+
+    INGREDIENT_NOT_FOUND("해당 재료를 찾을 수 없습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -45,7 +45,7 @@ public class IngredientService {
     // 유저가 가진 단일 재료 조회
     @Transactional(readOnly = true)
     public IngredientResponse getIngredient(User user, UUID ingredientId) {
-        Ingredient ingredient = ingredientRepository.findIngredientByIdAndUser(ingredientId, user)
+        Ingredient ingredient = ingredientRepository.findByIdAndUser(ingredientId, user)
                 .orElseThrow(IngredientExceptions.INGREDIENT_NOT_FOUND::toApiException);
 
         return IngredientResponse.from(ingredient);

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -4,6 +4,7 @@ import com.github.hurrcook.domain.ingredient.IngredientRepository;
 import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.entity.Ingredient;
+import com.github.hurrcook.domain.ingredient.exception.IngredientExceptions;
 import com.github.hurrcook.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +40,14 @@ public class IngredientService {
                 .stream()
                 .map(IngredientResponse::from)
                 .toList();
+    }
+
+    // 유저가 가진 단일 재료 조회
+    @Transactional(readOnly = true)
+    public IngredientResponse getIngredient(User user, UUID ingredientId) {
+        Ingredient ingredient = ingredientRepository.findIngredientByIdAndUser(ingredientId, user)
+                .orElseThrow(IngredientExceptions.INGREDIENT_NOT_FOUND::toApiException);
+
+        return IngredientResponse.from(ingredient);
     }
 }


### PR DESCRIPTION
## 📋 변경사항 요약

특정 재료 조회 api 구현


- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경


## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 단일 재료 조회 API 추가: GET /ingredients/{ingredientId}로 자신의 재료를 ID로 확인할 수 있습니다.
  * 사용자 범위로 보호된 조회: 로그인한 사용자의 소유 재료만 반환됩니다.
* **Bug Fixes**
  * 재료 미존재 시 표준화된 오류 응답 반환(INGREDIENT_NOT_FOUND: “해당 재료를 찾을 수 없습니다.”).
* **Behavior**
  * 응답은 기존 ApiResponse 포맷을 유지하며, 기존 목록 조회에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->