### PR TITLE
[0.2.0] HC-38 로그아웃 로직 수정 및 토큰 구조 변경

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.github.hurrcook.domain.auth.controller;
 
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
-import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.auth.service.AuthService;
+import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.response.ApiResponse;
 import com.github.hurrcook.global.security.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,12 +41,10 @@ public class AuthController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "사용자 세션 종료: 리프레시 토큰 삭제, 액세스 토큰 블랙리스트 처리")
-    public ApiResponse<Void> logout(HttpServletRequest request) { // 현재 액세스 토큰으로 요청
+    public ApiResponse<Void> logout(@AuthenticationPrincipal User user, HttpServletRequest request) { // 현재 액세스 토큰으로 요청
+
         String accessToken = jwtUtil.extractToken(request);
-        if (accessToken == null || accessToken.isBlank()) {
-            AuthExceptions.INVALID_TOKEN.toApiException();
-        }
-        authService.logout(accessToken);
+        authService.logout(accessToken,user);
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
@@ -1,17 +1,17 @@
 package com.github.hurrcook.domain.auth.controller;
 
+import com.github.hurrcook.domain.auth.dto.request.RefreshTokenRequest;
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
 import com.github.hurrcook.domain.auth.service.AuthService;
-import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.response.ApiResponse;
 import com.github.hurrcook.global.security.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -41,10 +41,10 @@ public class AuthController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "사용자 세션 종료: 리프레시 토큰 삭제, 액세스 토큰 블랙리스트 처리")
-    public ApiResponse<Void> logout(@AuthenticationPrincipal User user, HttpServletRequest request) { // 현재 액세스 토큰으로 요청
+    public ApiResponse<Void> logout( HttpServletRequest request, @Valid @RequestBody RefreshTokenRequest refreshTokenRequest) { // 현재 액세스 토큰으로 요청
 
         String accessToken = jwtUtil.extractToken(request);
-        authService.logout(accessToken,user);
+        authService.logout(accessToken,refreshTokenRequest.getRefreshToken());
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package com.github.hurrcook.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+
+    @NotNull
+    String refreshToken;
+}

--- a/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
@@ -13,7 +13,9 @@ public enum AuthExceptions implements ApiExceptions {
     AUTHENTICATION_FAILED("인증에 실패했습니다."),
     KAKAO_TOKEN_ISSUE_FAILED("카카오 토큰 발급에 실패했습니다."),
     KAKAO_USERINFO_REQUEST_FAILED("카카오 사용자 정보 조회에 실패했습니다."),
-    INVALID_USER_REQUEST("잘못된 사용자 요청입니다.");
+    INVALID_USER_REQUEST("잘못된 사용자 요청입니다."),
+    REFRESH_TOKEN_NOT_ALLOWED("리프레시 토큰은 사용할 수 없습니다");
+
 
 
     private final String message;

--- a/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
@@ -12,7 +12,8 @@ public enum AuthExceptions implements ApiExceptions {
     INVALID_TOKEN("유효하지 않은 토큰입니다."),
     AUTHENTICATION_FAILED("인증에 실패했습니다."),
     KAKAO_TOKEN_ISSUE_FAILED("카카오 토큰 발급에 실패했습니다."),
-    KAKAO_USERINFO_REQUEST_FAILED("카카오 사용자 정보 조회에 실패했습니다.");
+    KAKAO_USERINFO_REQUEST_FAILED("카카오 사용자 정보 조회에 실패했습니다."),
+    INVALID_USER_REQUEST("잘못된 사용자 요청입니다.");
 
 
     private final String message;

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.github.hurrcook.domain.auth.service;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.github.hurrcook.domain.auth.dto.response.CheckLoginFirst;
 import com.github.hurrcook.domain.auth.dto.response.KakaoTokenResponse;
 import com.github.hurrcook.domain.auth.dto.response.KakaoUserInfoResponse;
@@ -81,31 +80,33 @@ public class AuthService {
 
 
     /* 사용자 로그아웃: 액세스토큰 블랙리스트, 리프레시 토큰 삭제 */
-    @Transactional
-    public void logout(String accessToken){
-        try{
-            // 토큰에서 userId 추출
-            UUID userId = jwtUtil.extractIdFromToken(accessToken);
+//    @Transactional
+    public void logout(String accessToken,User user){
 
-            // 유저 유효성 검사
-            if (!userRepository.existsById(userId))
-                throw UserExceptions.USER_NOT_FOUND.toApiException();
+        // 토큰에서 userId 추출
+        UUID userId = jwtUtil.extractIdFromToken(accessToken);
 
-            refreshTokenRedisRepository.deleteByUserId(userId.toString()); // 유저의 리프레시 토큰 삭제
+        // 유저 유효성 검사
+        User logoutUser = userRepository.findById(userId).orElseThrow(UserExceptions.USER_NOT_FOUND::toApiException);
 
-            /* 액세스 토큰을 redis에 저장(blacked 상태) */
-            Instant expiration = jwtUtil.extractExpirationFromToken(accessToken); // 액세스 토큰 ttl
-            long remainingExpiration = expiration.toEpochMilli() - Instant.now().toEpochMilli(); // 남은 유효시간
-
-            // 남은 유효시간 만큼 블랙 리스트에 저장
-            if (remainingExpiration > 0) {
-                String key = "BLACKED_TOKEN" + accessToken;
-                String value = "blacklisted";
-                redisTemplate.opsForValue().set(key, value, Duration.ofMillis(remainingExpiration));
-            }
-        } catch (JWTVerificationException e){
-            throw AuthExceptions.INVALID_TOKEN.toApiException();
+        //사용자 권한 검증
+        if (!logoutUser.equals(user)){
+            throw AuthExceptions.INVALID_USER_REQUEST.toApiException();
         }
+
+        refreshTokenRedisRepository.deleteByUserId(userId.toString()); // 유저의 리프레시 토큰 삭제
+
+        /* 액세스 토큰을 redis에 저장(blacked 상태) */
+        Instant expiration = jwtUtil.extractExpirationFromToken(accessToken); // 액세스 토큰 ttl
+        long remainingExpiration = expiration.toEpochMilli() - Instant.now().toEpochMilli(); // 남은 유효시간
+
+        // 남은 유효시간 만큼 블랙 리스트에 저장
+        if (remainingExpiration > 0) {
+            String key = "BLACKED_TOKEN" + accessToken;
+            String value = "blacklisted";
+            redisTemplate.opsForValue().set(key, value, Duration.ofMillis(remainingExpiration));
+        }
+
     }
 
 

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -4,10 +4,10 @@ import com.github.hurrcook.domain.auth.dto.response.CheckLoginFirst;
 import com.github.hurrcook.domain.auth.dto.response.KakaoTokenResponse;
 import com.github.hurrcook.domain.auth.dto.response.KakaoUserInfoResponse;
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
+import com.github.hurrcook.domain.auth.entity.RefreshToken;
 import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.cookware.entity.Cookware;
 import com.github.hurrcook.domain.user.entity.User;
-import com.github.hurrcook.domain.user.exception.UserExceptions;
 import com.github.hurrcook.domain.user.repository.RefreshTokenRedisRepository;
 import com.github.hurrcook.domain.user.repository.UserRepository;
 import com.github.hurrcook.global.security.jwt.JwtUtil;
@@ -24,7 +24,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -80,21 +79,12 @@ public class AuthService {
 
 
     /* 사용자 로그아웃: 액세스토큰 블랙리스트, 리프레시 토큰 삭제 */
-//    @Transactional
-    public void logout(String accessToken,User user){
+    @Transactional
+    public void logout(String accessToken,String token){
 
-        // 토큰에서 userId 추출
-        UUID userId = jwtUtil.extractIdFromToken(accessToken);
-
-        // 유저 유효성 검사
-        User logoutUser = userRepository.findById(userId).orElseThrow(UserExceptions.USER_NOT_FOUND::toApiException);
-
-        //사용자 권한 검증
-        if (!logoutUser.equals(user)){
-            throw AuthExceptions.INVALID_USER_REQUEST.toApiException();
-        }
-
-        refreshTokenRedisRepository.deleteByUserId(userId.toString()); // 유저의 리프레시 토큰 삭제
+        // 유저의 리프레시 토큰 삭제
+        RefreshToken refreshToken = refreshTokenRedisRepository.findByRefreshToken(token).orElseThrow(AuthExceptions.INVALID_TOKEN::toApiException);
+        refreshTokenRedisRepository.delete(refreshToken);
 
         /* 액세스 토큰을 redis에 저장(blacked 상태) */
         Instant expiration = jwtUtil.extractExpirationFromToken(accessToken); // 액세스 토큰 ttl

--- a/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/user/repository/RefreshTokenRedisRepository.java
@@ -6,10 +6,8 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Repository
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
-    void deleteByUserId(String userId);
 }

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtFilter.java
@@ -44,6 +44,10 @@ public class JwtFilter extends OncePerRequestFilter {
         try{
             if (jwtUtil.validateToken(accessToken)) {
 
+                if (jwtUtil.extractTypeOfToken(accessToken).equals("RefreshToken")) {
+                    throw AuthExceptions.REFRESH_TOKEN_NOT_ALLOWED.toApiException();
+                }
+
                 // 요청 시 black 처리된 액세스 토큰인지 확인
                 String key = "BLACKED_TOKEN" + accessToken;
                 if (redisTemplate.hasKey(key)) {

--- a/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/github/hurrcook/global/security/jwt/JwtUtil.java
@@ -37,6 +37,7 @@ public class JwtUtil {
                 .withIssuedAt(Instant.now())
                 .withExpiresAt(Instant.now().plus(jwtProperty.getAccessExpiration(), ChronoUnit.HOURS))
                 .withClaim("id",user.getId().toString())
+                .withClaim("type","AccessToken")
                 .sign(algorithm());
     }
 
@@ -45,6 +46,7 @@ public class JwtUtil {
                 .withIssuedAt(Instant.now())
                 .withExpiresAt(Instant.now().plus(jwtProperty.getRefreshExpiration(), ChronoUnit.HOURS))
                 .withClaim("id",user.getId().toString()) // baseSchema Id
+                .withClaim("type","RefreshToken")
                 .sign(algorithm());
 
         // refreshToken 엔티티 생성 및 저장
@@ -94,6 +96,11 @@ public class JwtUtil {
     public UUID extractIdFromToken(String token){
 
         return JWT.decode(token).getClaim("id").as(UUID.class);
+    }
+
+    public String extractTypeOfToken(String token){
+
+        return JWT.decode(token).getClaim("type").as(String.class);
     }
 
     public Instant extractExpirationFromToken(String token){


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [ ] 새로운 기능 추가
- [x] 기존 기능 개선
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그아웃 시 리프레시 토큰을 함께 제출하여 세션을 안전하게 종료합니다.
  - 토큰에 타입 정보(AccessToken/RefreshToken)를 내장하고 타입 조회를 지원합니다.
  - 로그아웃 요청 본문에 리프레시 토큰이 필수로 변경되었습니다.
- Bug Fixes
  - 인증 필터에서 리프레시 토큰으로의 인증 시도를 차단하여 오용을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->