### PR TITLE
[0.2.0] HC-39 토큰 재발급 로직 생성

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.github.hurrcook.domain.auth.controller;
 
 import com.github.hurrcook.domain.auth.dto.request.RefreshTokenRequest;
 import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
+import com.github.hurrcook.domain.auth.dto.response.TokenResponse;
 import com.github.hurrcook.domain.auth.service.AuthService;
 import com.github.hurrcook.global.response.ApiResponse;
 import com.github.hurrcook.global.security.jwt.JwtUtil;
@@ -46,5 +47,14 @@ public class AuthController {
         String accessToken = jwtUtil.extractToken(request);
         authService.logout(accessToken,refreshTokenRequest.getRefreshToken());
         return ApiResponse.ok();
+    }
+
+    @PostMapping("/reissuance")
+    @Operation(summary = "토큰 재발급")
+    public ApiResponse<TokenResponse> reissuance(HttpServletRequest request, @Valid @RequestBody RefreshTokenRequest refreshTokenRequest) {
+
+        String accessToken = jwtUtil.extractToken(request);
+
+        return ApiResponse.ok(authService.regenerateToken(accessToken,refreshTokenRequest.getRefreshToken()));
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/dto/response/LoginResponse.java
@@ -19,5 +19,5 @@ public class LoginResponse {
 
     @JsonProperty("refreshToken") private String refreshToken;
 
-    @JsonProperty("isFirstLogin") private boolean isFirstLogin;
+    @JsonProperty("firstLogin") private boolean firstLogin;
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.github.hurrcook.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class TokenResponse {
+
+    @JsonProperty("accessToken") private String accessToken;
+
+    @JsonProperty("refreshToken")private String refreshToken;
+}

--- a/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/exception/AuthExceptions.java
@@ -13,8 +13,9 @@ public enum AuthExceptions implements ApiExceptions {
     AUTHENTICATION_FAILED("인증에 실패했습니다."),
     KAKAO_TOKEN_ISSUE_FAILED("카카오 토큰 발급에 실패했습니다."),
     KAKAO_USERINFO_REQUEST_FAILED("카카오 사용자 정보 조회에 실패했습니다."),
-    INVALID_USER_REQUEST("잘못된 사용자 요청입니다."),
-    REFRESH_TOKEN_NOT_ALLOWED("리프레시 토큰은 사용할 수 없습니다");
+    REFRESH_TOKEN_NOT_ALLOWED("리프레시 토큰은 사용할 수 없습니다"),
+    REFRESH_TOKEN_EXPIRED("리프레쉬 토큰이 만료되었습니다"),
+    TOKEN_NOT_PAIR("엑세스 토큰과 리프레쉬 토큰의 정보가 다릅니다");
 
 
 

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -1,13 +1,11 @@
 package com.github.hurrcook.domain.auth.service;
 
-import com.github.hurrcook.domain.auth.dto.response.CheckLoginFirst;
-import com.github.hurrcook.domain.auth.dto.response.KakaoTokenResponse;
-import com.github.hurrcook.domain.auth.dto.response.KakaoUserInfoResponse;
-import com.github.hurrcook.domain.auth.dto.response.LoginResponse;
+import com.github.hurrcook.domain.auth.dto.response.*;
 import com.github.hurrcook.domain.auth.entity.RefreshToken;
 import com.github.hurrcook.domain.auth.exception.AuthExceptions;
 import com.github.hurrcook.domain.cookware.entity.Cookware;
 import com.github.hurrcook.domain.user.entity.User;
+import com.github.hurrcook.domain.user.exception.UserExceptions;
 import com.github.hurrcook.domain.user.repository.RefreshTokenRedisRepository;
 import com.github.hurrcook.domain.user.repository.UserRepository;
 import com.github.hurrcook.global.security.jwt.JwtUtil;
@@ -24,6 +22,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -86,16 +85,27 @@ public class AuthService {
         RefreshToken refreshToken = refreshTokenRedisRepository.findByRefreshToken(token).orElseThrow(AuthExceptions.INVALID_TOKEN::toApiException);
         refreshTokenRedisRepository.delete(refreshToken);
 
-        /* 액세스 토큰을 redis에 저장(blacked 상태) */
-        Instant expiration = jwtUtil.extractExpirationFromToken(accessToken); // 액세스 토큰 ttl
-        long remainingExpiration = expiration.toEpochMilli() - Instant.now().toEpochMilli(); // 남은 유효시간
+        addToBlacklist(accessToken);
 
-        // 남은 유효시간 만큼 블랙 리스트에 저장
-        if (remainingExpiration > 0) {
-            String key = "BLACKED_TOKEN" + accessToken;
-            String value = "blacklisted";
-            redisTemplate.opsForValue().set(key, value, Duration.ofMillis(remainingExpiration));
+    }
+    @Transactional
+    public TokenResponse regenerateToken(String accessToken,String refreshToken){
+
+        RefreshToken redisRefreshToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken).orElseThrow(AuthExceptions.REFRESH_TOKEN_EXPIRED::toApiException);
+
+        UUID userId = jwtUtil.extractIdFromToken(accessToken);
+
+        if (!userId.toString().equals(redisRefreshToken.userId())){
+            throw AuthExceptions.TOKEN_NOT_PAIR.toApiException();
         }
+
+        refreshTokenRedisRepository.delete(redisRefreshToken);
+        User user = userRepository.findById(userId).orElseThrow(UserExceptions.USER_NOT_FOUND::toApiException);
+
+        String newAccessToken = jwtUtil.createAccessToken(user);
+        String newRefreshToken = jwtUtil.createRefreshToken(user);
+
+        return TokenResponse.of(newAccessToken,newRefreshToken);
 
     }
 
@@ -179,6 +189,7 @@ public class AuthService {
             throw AuthExceptions.KAKAO_USERINFO_REQUEST_FAILED.toApiException();
         }
     }
+
     private User of(Long kakaoId, String name){
         User user = User.builder()
                 .kakaoId(kakaoId)
@@ -189,6 +200,20 @@ public class AuthService {
         user.setCookware(cookware);
 
         return userRepository.save(user);
+    }
+
+    private void addToBlacklist(String token){
+
+        /* 액세스 토큰을 redis에 저장(blacked 상태) */
+        Instant expiration = jwtUtil.extractExpirationFromToken(token); // 액세스 토큰 ttl
+        long remainingExpiration = expiration.toEpochMilli() - Instant.now().toEpochMilli(); // 남은 유효시간
+
+        // 남은 유효시간 만큼 블랙 리스트에 저장
+        if (remainingExpiration > 0) {
+            String key = "BLACKED_TOKEN" + token;
+            String value = "blacklisted";
+            redisTemplate.opsForValue().set(key, value, Duration.ofMillis(remainingExpiration));
+        }
     }
 
 }

--- a/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
+++ b/src/main/java/com/github/hurrcook/domain/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -90,6 +91,10 @@ public class AuthService {
     }
     @Transactional
     public TokenResponse regenerateToken(String accessToken,String refreshToken){
+
+        if(Objects.isNull(accessToken)){
+            throw AuthExceptions.INVALID_TOKEN.toApiException();
+        }
 
         RefreshToken redisRefreshToken = refreshTokenRedisRepository.findByRefreshToken(refreshToken).orElseThrow(AuthExceptions.REFRESH_TOKEN_EXPIRED::toApiException);
 

--- a/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
+++ b/src/main/java/com/github/hurrcook/global/config/SecurityConfig.java
@@ -35,7 +35,9 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth-> auth
                         .requestMatchers(
-                                "/auth/**",
+                                "/auth/kakao/login",
+                                "/auth/kakao/callback",
+                                "/auth/reissuance",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 토큰 재발급 API(POST /auth/reissuance) 추가 — 새 accessToken/refreshToken을 반환합니다.
- **Refactor**
  - 인증 경로 접근 제어 세분화: /auth/kakao/login, /auth/kakao/callback, /auth/reissuance만 공개; 나머지 /auth/*는 인증 필요.
- **Chores**
  - 로그인 응답 필드명 정규화(isFirstLogin → firstLogin).
  - 리프레시 토큰 만료 및 액세스/리프레시 불일치에 대한 오류 코드·메시지 추가.
  - 로그아웃 동작은 변경 없음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->