### PR TITLE
[0.3.0] HC-42 재료 정보 수정 api

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.ingredient.controller;
 
 import com.github.hurrcook.domain.ingredient.dto.request.IngredientListRequest;
+import com.github.hurrcook.domain.ingredient.dto.request.IngredientUpdateRequest;
 import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseListRequest;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.service.IngredientService;
@@ -52,5 +53,12 @@ public class IngredientController {
     @Operation(summary = "단일 재료 조회")
     public ApiResponse<IngredientResponse> getIngredient(@AuthenticationPrincipal User user, @PathVariable UUID ingredientId) {
         return ApiResponse.ok(ingredientService.getIngredient(user, ingredientId));
+    }
+
+    @PutMapping("/{ingredientId}")
+    @Operation(summary = "재료 정보 수정")
+    public ApiResponse<Void> updateIngredient(@AuthenticationPrincipal User user, @PathVariable UUID ingredientId, @RequestBody @Valid IngredientUpdateRequest ingredientUpdateRequest) {
+        ingredientService.updateIngredient(user, ingredientId, ingredientUpdateRequest);
+        return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientUpdateRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.github.hurrcook.domain.ingredient.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class IngredientUpdateRequest {
+
+    @NotBlank
+    @Schema(description = "재료 이름")
+    String name;
+
+    @Positive
+    @Schema(description = "수량")
+    int amount;
+
+    @NotNull
+    @Schema(description = "유통기한")
+    LocalDateTime expireDate;
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -1,10 +1,7 @@
 package com.github.hurrcook.domain.ingredient.service;
 
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientListRequest;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseListRequest;
+import com.github.hurrcook.domain.ingredient.dto.request.*;
 import com.github.hurrcook.domain.ingredient.repository.IngredientRepository;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseRequest;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.entity.Ingredient;
 import com.github.hurrcook.domain.ingredient.exception.IngredientExceptions;
@@ -80,5 +77,18 @@ public class IngredientService {
                 .orElseThrow(IngredientExceptions.INGREDIENT_NOT_FOUND::toApiException);
 
         return IngredientResponse.from(ingredient);
+    }
+
+    @Transactional
+    public void updateIngredient(User user, UUID ingredientId, IngredientUpdateRequest ingredientUpdateRequest) {
+
+        Ingredient ingredient = ingredientRepository.findByIdAndUser(ingredientId, user)
+                .orElseThrow(IngredientExceptions.INGREDIENT_NOT_FOUND::toApiException);
+
+        ingredient.setName(ingredientUpdateRequest.getName());
+        ingredient.setAmount(ingredientUpdateRequest.getAmount());
+        ingredient.setExpireDate(ingredientUpdateRequest.getExpireDate());
+
+        ingredientRepository.save(ingredient);
     }
 }


### PR DESCRIPTION
## 📋 변경사항 요약

<!-- 이 PR에서 변경된 내용을 간단히 요약해 주세요 -->

## 🎯 변경 이유

<!-- 왜 이런 변경이 필요했는지 설명해 주세요 -->

## 🔧 주요 변경사항

<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 재료 수정 API 추가 (PUT /ingredients/{ingredientId}): 인증된 사용자가 이름, 수량, 유통기한을 수정할 수 있습니다.
- 개선
  - 요청 유효성 강화: 이름은 공백 불가, 수량은 양수, 유통기한은 필수로 유효하지 않은 입력을 차단합니다.
- 문서
  - API 문서에 각 필드 설명을 추가해 스펙 가독성과 사용성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->