### PR TITLE
[0.1.0] HC-40 재료 차감 목록 조회 API

### DIFF
--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -2,7 +2,9 @@ package com.github.hurrcook.domain.ingredient.controller;
 
 import com.github.hurrcook.domain.ingredient.dto.request.IngredientListRequest;
 import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseListRequest;
+import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseRequest;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
+import com.github.hurrcook.domain.ingredient.dto.response.IngredientReduceResponse;
 import com.github.hurrcook.domain.ingredient.service.IngredientService;
 import com.github.hurrcook.domain.user.entity.User;
 import com.github.hurrcook.global.response.ApiResponse;
@@ -31,6 +33,12 @@ public class IngredientController {
         ingredientService.addIngredient(user, ingredientRequests);
 
         return ApiResponse.ok();
+    }
+
+    @GetMapping("/usage")
+    @Operation(summary = "재료 차감 목록 불러오기(레시피로 요리하기 요청하여 필요한 재료 정보를 담아 보내고, 응답 받음")
+    public ApiResponse<List<IngredientReduceResponse>> getUsageIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid List<IngredientUseRequest> request){
+        return ApiResponse.ok(ingredientService.getUsageIngredient(user, request));
     }
 
     @PutMapping

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -1,9 +1,6 @@
 package com.github.hurrcook.domain.ingredient.controller;
 
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientListRequest;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientUpdateRequest;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseListRequest;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseRequest;
+import com.github.hurrcook.domain.ingredient.dto.request.*;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientReduceResponse;
 import com.github.hurrcook.domain.ingredient.service.IngredientService;
@@ -38,7 +35,7 @@ public class IngredientController {
 
     @PostMapping("/usage")
     @Operation(summary = "재료 차감 목록 불러오기(레시피로 요리하기 요청하여 필요한 재료 정보를 담아 보내고, 응답 받음)")
-    public ApiResponse<List<IngredientReduceResponse>> getUsageIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid List<IngredientUseRequest> request){
+    public ApiResponse<List<IngredientReduceResponse>> getUsageIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid List<IngredientUseCheckRequest> request){
         return ApiResponse.ok(ingredientService.getUsageIngredient(user, request));
     }
 

--- a/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/controller/IngredientController.java
@@ -36,8 +36,8 @@ public class IngredientController {
         return ApiResponse.ok();
     }
 
-    @GetMapping("/usage")
-    @Operation(summary = "재료 차감 목록 불러오기(레시피로 요리하기 요청하여 필요한 재료 정보를 담아 보내고, 응답 받음")
+    @PostMapping("/usage")
+    @Operation(summary = "재료 차감 목록 불러오기(레시피로 요리하기 요청하여 필요한 재료 정보를 담아 보내고, 응답 받음)")
     public ApiResponse<List<IngredientReduceResponse>> getUsageIngredient(@AuthenticationPrincipal User user, @RequestBody @Valid List<IngredientUseRequest> request){
         return ApiResponse.ok(ingredientService.getUsageIngredient(user, request));
     }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientUseCheckRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientUseCheckRequest.java
@@ -1,0 +1,21 @@
+package com.github.hurrcook.domain.ingredient.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class IngredientUseCheckRequest {
+
+    @NotNull
+    @Schema(description = "음식 재료명")
+    String name;
+
+    @NotNull
+    @PositiveOrZero
+    @Schema(description = "사용 수량")
+    int useAmount;
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientUseRequest.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/request/IngredientUseRequest.java
@@ -17,5 +17,5 @@ public class IngredientUseRequest {
     @NotNull
     @PositiveOrZero
     @Schema(description = "사용 수량")
-    Integer useAmount;
+    int useAmount;
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientReduceResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientReduceResponse.java
@@ -1,0 +1,54 @@
+package com.github.hurrcook.domain.ingredient.dto.response;
+
+import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseRequest;
+import com.github.hurrcook.domain.ingredient.entity.Ingredient;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter @Builder
+public class IngredientReduceResponse {
+    @Schema(description = "재료 아이디")
+    private UUID userFoodId;
+
+    @Schema(description = "재료명")
+    private String name;
+
+    @Schema(description = "레시피에 필요한 재료 수량")
+    private int useAmount;
+
+    @Schema(description = "유저가 가진 재료 수량")
+    private int currentAmount;
+
+    @Schema(description = "유저가 가진 재료의 유통기한")
+    private LocalDateTime expireDate;
+
+    @Schema(description = "재료량의 충분 상태 여부")
+    private boolean sufficient;
+
+    public static IngredientReduceResponse from(IngredientUseRequest request, Ingredient ingredient,
+                                                int currentAmount, boolean sufficient) {
+        return IngredientReduceResponse.builder()
+                .userFoodId(request.getUserFoodId())
+                .name(ingredient.getName())
+                .useAmount(request.getUseAmount())
+                .currentAmount(currentAmount)
+                .expireDate(ingredient.getExpireDate())
+                .sufficient(sufficient)
+                .build();
+    }
+
+    public static IngredientReduceResponse fromNotOwned(IngredientUseRequest request, String foodName) {
+        return IngredientReduceResponse.builder()
+                .userFoodId(request.getUserFoodId())
+                .name(foodName)
+                .useAmount(request.getUseAmount())
+                .currentAmount(0)
+                .expireDate(null)
+                .sufficient(false)
+                .build();
+    }
+}

--- a/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientReduceResponse.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/dto/response/IngredientReduceResponse.java
@@ -40,15 +40,4 @@ public class IngredientReduceResponse {
                 .sufficient(sufficient)
                 .build();
     }
-
-    public static IngredientReduceResponse fromNotOwned(IngredientUseRequest request, String foodName) {
-        return IngredientReduceResponse.builder()
-                .userFoodId(request.getUserFoodId())
-                .name(foodName)
-                .useAmount(request.getUseAmount())
-                .currentAmount(0)
-                .expireDate(null)
-                .sufficient(false)
-                .build();
-    }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/repository/IngredientRepository.java
@@ -12,5 +12,6 @@ public interface IngredientRepository extends JpaRepository<Ingredient, UUID> {
     
     List<Ingredient> findAllByUser(User user);
     Optional<Ingredient> findByIdAndUser(UUID ingredientId, User user);
+    List<Ingredient> findAllByUserAndName(User user, String name);
     List<Ingredient> findByUserAndIdIn(User user, List<UUID> ingredientIds);
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -1,6 +1,7 @@
 package com.github.hurrcook.domain.ingredient.service;
 
 import com.github.hurrcook.domain.ingredient.dto.request.*;
+import com.github.hurrcook.domain.ingredient.dto.response.IngredientReduceResponse;
 import com.github.hurrcook.domain.ingredient.repository.IngredientRepository;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.entity.Ingredient;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -83,28 +85,76 @@ public class IngredientService {
   
     // 재료 차감 목록 불러오기
     @Transactional(readOnly = true)
-    public List<IngredientReduceResponse> getUsageIngredient(User user, List<IngredientUseRequest> request) {
-        // 유저의 모든 재료 조회
-        Map<UUID, Ingredient> allUserIngredients = ingredientRepository.findAllByUser(user)
-                .stream()
-                .collect(Collectors.toMap(Ingredient::getId, ingredient -> ingredient));
+    public List<IngredientReduceResponse> getUsageIngredient(User user, List<IngredientUseCheckRequest> requests) {
+        return requests.stream()
+                .flatMap(required -> {
+                    String name = required.getName();
+                    int remaining = required.getUseAmount(); // 필요 재료량 상태
 
-        return request.stream() // 요청으로 받은 재료 리스트
-                .map(required -> {
-                    // 유저가 가진 재료 중에서 요청 받은 재료를 찾음
-                    Ingredient owned = allUserIngredients.get(required.getUserFoodId());
+                    // 유저가 가진 동일 이름의 재료를 유통기한 오름차순으로 조회
+                    List<Ingredient> ownedIngredients = ingredientRepository.findAllByUserAndName(user, name)
+                            .stream()
+                            .sorted(Comparator.comparing(Ingredient::getExpireDate))
+                            .collect(Collectors.toList());
 
-                    if (owned == null)  return null;
+                    // 재료가 하나도 없는 경우
+                    if (ownedIngredients.isEmpty()) {
+                        return Stream.of(IngredientReduceResponse.builder()
+                                .userFoodId(null)
+                                .name(name)
+                                .useAmount(required.getUseAmount())
+                                .currentAmount(0)
+                                .expireDate(null)
+                                .sufficient(false)
+                                .build());
+                    }
 
-                    int currentAmount = owned.getAmount();
-                    boolean isSufficient = currentAmount >= required.getUseAmount();
+                    List<IngredientReduceResponse> result = new ArrayList<>();
 
-                    return IngredientReduceResponse.from(required, owned, currentAmount, isSufficient);
+                    // 유통기한 빠른 재료부터 먼저 사용 가능한지 확인
+                    for (Ingredient ingredient : ownedIngredients) {
+                        if (remaining <= 0) break; // 더 이상 차감 필요 없음
 
+                        int available = ingredient.getAmount(); // 기존 db 재료가 가진 양
+                        int used = Math.min(available, remaining);
+                        remaining -= used;
+
+                        result.add(IngredientReduceResponse.builder()
+                                .userFoodId(ingredient.getId())
+                                .name(ingredient.getName())
+                                .useAmount(used)
+                                .currentAmount(ingredient.getAmount())
+                                .expireDate(ingredient.getExpireDate())
+                                .sufficient(true)
+                                .build());
+                    }
+
+                    // 남은 양이 있으면 재료 부족 처리
+                    if (remaining > 0) {
+                        // 마지막 항목에 부족 상태 표시
+                        result.add(IngredientReduceResponse.builder()
+                                .userFoodId(null)
+                                .name(name)
+                                .useAmount(remaining)
+                                .currentAmount(0)
+                                .expireDate(null)
+                                .sufficient(false)
+                                .build());
+                    }
+
+                    return result.stream();
                 })
-                .collect(Collectors.toList());
+                .toList();
+    }
 
-  
+    @Transactional
+    public void deleteIngredient(User user, UUID ingredientId) {
+        Ingredient ingredient = ingredientRepository.findByIdAndUser(ingredientId, user)
+                .orElseThrow(IngredientExceptions.INGREDIENT_NOT_FOUND::toApiException);
+
+        ingredientRepository.delete(ingredient);
+    }
+
     @Transactional
     public void updateIngredient(User user, UUID ingredientId, IngredientUpdateRequest ingredientUpdateRequest) {
 
@@ -116,14 +166,5 @@ public class IngredientService {
         ingredient.setExpireDate(ingredientUpdateRequest.getExpireDate());
 
         ingredientRepository.save(ingredient);
-    }
-    
-      
-    @Transactional
-    public void deleteIngredient(User user, UUID ingredientId) {
-        Ingredient ingredient = ingredientRepository.findByIdAndUser(ingredientId, user)
-                .orElseThrow(IngredientExceptions.INGREDIENT_NOT_FOUND::toApiException);
-
-        ingredientRepository.delete(ingredient);
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -1,10 +1,8 @@
 package com.github.hurrcook.domain.ingredient.service;
 
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientListRequest;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseListRequest;
+import com.github.hurrcook.domain.ingredient.dto.request.*;
+import com.github.hurrcook.domain.ingredient.dto.response.IngredientReduceResponse;
 import com.github.hurrcook.domain.ingredient.repository.IngredientRepository;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientUseRequest;
-import com.github.hurrcook.domain.ingredient.dto.request.IngredientRequest;
 import com.github.hurrcook.domain.ingredient.dto.response.IngredientResponse;
 import com.github.hurrcook.domain.ingredient.entity.Ingredient;
 import com.github.hurrcook.domain.ingredient.exception.IngredientExceptions;
@@ -80,5 +78,51 @@ public class IngredientService {
                 .orElseThrow(IngredientExceptions.INGREDIENT_NOT_FOUND::toApiException);
 
         return IngredientResponse.from(ingredient);
+    }
+
+    // 재료 차감 목록 불러오기
+    @Transactional(readOnly = true)
+    public List<IngredientReduceResponse> getUsageIngredient(User user, List<IngredientUseRequest> request) {
+        // 유저의 모든 재료 조회
+        Map<UUID, Ingredient> allUserIngredients = ingredientRepository.findAllByUser(user)
+                .stream()
+                .collect(Collectors.toMap(Ingredient::getId, ingredient -> ingredient));
+
+        // 보유하지 않은 재료 ID
+        Set<UUID> notOwnedIds = request.stream()
+                .map(IngredientUseRequest::getUserFoodId)
+                .filter(id -> !allUserIngredients.containsKey(id))
+                .collect(Collectors.toSet());
+
+        // 보유하지 않은 재료의 이름
+        Map<UUID, String> notOwnedNames = new HashMap<>();
+        if (!notOwnedIds.isEmpty()) {
+            notOwnedNames = ingredientRepository.findAllById(notOwnedIds)
+                    .stream()
+                    .collect(Collectors.toMap(Ingredient::getId, Ingredient::getName));
+        }
+
+        final Map<UUID, String> finalNotOwnedNames = notOwnedNames;
+
+        return request.stream() // 요청으로 받은 재료 리스트
+                .map(required -> {
+                    // 유저가 가진 재료 중에서 요청 받은 재료를 찾음
+                    Ingredient owned = allUserIngredients.get(required.getUserFoodId());
+
+                    if (owned == null){
+                        String foodName = finalNotOwnedNames.get(required.getUserFoodId());
+                        if (foodName == null) {
+                            throw IngredientExceptions.INGREDIENT_NOT_FOUND.toApiException();
+                        }
+                        return IngredientReduceResponse.fromNotOwned(required, foodName);
+                    }
+
+                    int currentAmount = owned.getAmount();
+                    boolean isSufficient = currentAmount >= required.getUseAmount();
+
+                    return IngredientReduceResponse.from(required, owned, currentAmount, isSufficient);
+
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/github/hurrcook/domain/ingredient/service/IngredientService.java
@@ -89,34 +89,12 @@ public class IngredientService {
                 .stream()
                 .collect(Collectors.toMap(Ingredient::getId, ingredient -> ingredient));
 
-        // 보유하지 않은 재료 ID
-        Set<UUID> notOwnedIds = request.stream()
-                .map(IngredientUseRequest::getUserFoodId)
-                .filter(id -> !allUserIngredients.containsKey(id))
-                .collect(Collectors.toSet());
-
-        // 보유하지 않은 재료의 이름
-        Map<UUID, String> notOwnedNames = new HashMap<>();
-        if (!notOwnedIds.isEmpty()) {
-            notOwnedNames = ingredientRepository.findAllById(notOwnedIds)
-                    .stream()
-                    .collect(Collectors.toMap(Ingredient::getId, Ingredient::getName));
-        }
-
-        final Map<UUID, String> finalNotOwnedNames = notOwnedNames;
-
         return request.stream() // 요청으로 받은 재료 리스트
                 .map(required -> {
                     // 유저가 가진 재료 중에서 요청 받은 재료를 찾음
                     Ingredient owned = allUserIngredients.get(required.getUserFoodId());
 
-                    if (owned == null){
-                        String foodName = finalNotOwnedNames.get(required.getUserFoodId());
-                        if (foodName == null) {
-                            throw IngredientExceptions.INGREDIENT_NOT_FOUND.toApiException();
-                        }
-                        return IngredientReduceResponse.fromNotOwned(required, foodName);
-                    }
+                    if (owned == null)  return null;
 
                     int currentAmount = owned.getAmount();
                     boolean isSufficient = currentAmount >= required.getUseAmount();


### PR DESCRIPTION
## 📋 변경사항 요약

재료 차감 목록 조회 API를 추가했습니다. 


<!-- 구체적인 변경 내용을 나열해 주세요 -->

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정
- [ ] 설정 변경

## 🔍 검토 포인트

<!-- 리뷰어가 특별히 확인했으면 하는 부분이 있다면 명시해 주세요 -->

## ✅ 체크리스트

<!-- PR 제출 전 확인사항들을 체크해 주세요 -->

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 검토를 완료했습니다
- [ ] 문서를 업데이트했습니다 (해당하는 경우)
- [x] 변경사항이 기존 테스트를 통과합니다

## 📝 추가 노트

<!-- 리뷰어에게 전달하고 싶은 추가 정보가 있다면 작성해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 재료 사용 검증 API 추가: POST /ingredients/usage
  - 여러 재료를 한 번에 요청하면 항목별로 보유 여부, 현재 보유량, 유통기한, 요청 충족 여부(sufficient)를 항목 순서에 맞춰 반환
  - 요청 수량은 0 이상의 정수로 처리되며, 누락 시 0으로 간주되고 부분 충족 시 부족 항목을 별도로 표시합니다
<!-- end of auto-generated comment: release notes by coderabbit.ai -->